### PR TITLE
refactor(year-selector): use Link component and refine class

### DIFF
--- a/app/ui/year-selector.tsx
+++ b/app/ui/year-selector.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from 'fumadocs-ui/components/ui/popover';
+import Link from 'fumadocs-core/link';
 import { Check, ChevronsUpDown } from 'lucide-react';
 import { useState } from 'react';
 
@@ -16,24 +16,23 @@ export function YearSelector({
   years: string[];
   currentYear: string;
 }) {
-  const router = useRouter();
   const [open, setOpen] = useState(false);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger
-        className="flex w-full items-center gap-2 rounded-lg p-2 border bg-fd-secondary/50 text-start text-fd-secondary-foreground transition-colors hover:bg-fd-accent data-[state=open]:bg-fd-accent data-[state=open]:text-fd-accent-foreground"
+        className="flex items-center gap-2 rounded-lg p-2 border bg-fd-secondary/50 text-start text-fd-secondary-foreground transition-colors hover:bg-fd-accent data-[state=open]:bg-fd-accent data-[state=open]:text-fd-accent-foreground"
       >
         <span className="text-sm font-medium">{currentYear}</span>
         <ChevronsUpDown className="shrink-0 ms-auto size-4 text-fd-muted-foreground" />
       </PopoverTrigger>
-      <PopoverContent className="flex flex-col gap-1 w-(--radix-popover-trigger-width) p-1">
+      <PopoverContent className="flex flex-col gap-1 w-(--radix-popover-trigger-width) p-1 fd-scroll-container">
         {years.map((year) => (
-          <button
+          <Link
             key={year}
-            className="flex items-center gap-2 rounded-lg p-1.5 hover:bg-fd-accent hover:text-fd-accent-foreground text-start"
+            className="flex items-center gap-2 rounded-lg p-1.5 hover:bg-fd-accent hover:text-fd-accent-foreground"
+            href={`/docs/${year}`}
             onClick={() => {
-              router.push(`/docs/${year}`);
               setOpen(false);
             }}
           >
@@ -41,7 +40,7 @@ export function YearSelector({
             <Check
               className={`shrink-0 ms-auto size-3.5 text-fd-primary ${year !== currentYear ? 'invisible' : ''}`}
             />
-          </button>
+          </Link>
         ))}
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
This implementation refers from https://github.com/fuma-nama/fumadocs/blob/dev/packages/ui/src/components/sidebar/tabs/dropdown.tsx

It nows use Link instead of butto, which enables prefetch for faster loading and avoid full page refresh.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored YearSelector to use the fumadocs Link component for year options, enabling prefetch and smoother navigation without full page reloads. Also adjusted styles by removing the trigger’s full-width class and adding fd-scroll-container to the dropdown for better scrolling.

<sup>Written for commit 3c84d4569d0dce51aa50116ca9bc7caf72ab9520. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

