### PR TITLE
feat: add Chinese search support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PM := pnpm
 
-.PHONY: help prepare sync docs run build start clean clean-docs lint format check
+.PHONY: help prepare sync docs dev build start clean clean-docs lint format check
 
 help:
 	@printf "%s\n" \
@@ -8,7 +8,7 @@ help:
 		"  prepare     Install frontend deps and sync scripts venv" \
 		"  sync        Sync scripts venv from uv.lock (.python-version driven)" \
 		"  docs        Run scripts/main.py and format_mdx.py" \
-		"  run         Launch the frontend dev server" \
+		"  dev         Launch the frontend dev server" \
 		"  build       Build the frontend" \
 		"  start       Start the built frontend (production)" \
 		"  lint        Lint frontend and scripts" \
@@ -26,7 +26,7 @@ prepare:
 docs:
 	fuma_rs --fetch
 
-run:
+dev:
 	$(PM) run dev
 
 build:
@@ -46,7 +46,7 @@ format:
 check: lint format
 
 clean:
-	rm -rf node_modules .next .source scripts/.venv
+	rm -rf node_modules .next .source
 
 clean-docs:
 	rm -rf content/docs/

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,7 +1,18 @@
 import { source } from '@/lib/source';
 import { createFromSource } from 'fumadocs-core/search/server';
+import { createTokenizer } from '@orama/tokenizers/mandarin';
 
 export const { GET } = createFromSource(source, {
-  // https://docs.orama.com/docs/orama-js/supported-languages
-  language: 'english',
+  localeMap: {
+    // [locale]: Orama options
+    cn: {
+      components: {
+        tokenizer: createTokenizer(),
+      },
+      search: {
+        threshold: 0,
+        tolerance: 0,
+      },
+    },
+  },
 });

--- a/app/docs/[year]/layout.tsx
+++ b/app/docs/[year]/layout.tsx
@@ -11,7 +11,8 @@ export default async function Layout(props: {
   params: Promise<{ year: string }>;
 }) {
   const { year } = await props.params;
-  const yearNode = source.pageTree.children.find(
+  const pageTree = source.getPageTree();
+  const yearNode = pageTree.children.find(
     (node): node is Folder => node.type === 'folder' && node.name === year
   );
 

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -1,0 +1,6 @@
+import { defineI18n } from 'fumadocs-core/i18n';
+
+export const i18n = defineI18n({
+  defaultLanguage: 'cn',
+  languages: ['cn'],
+});

--- a/lib/source.tsx
+++ b/lib/source.tsx
@@ -2,12 +2,14 @@ import { docs, blogPosts, newsPosts } from 'fumadocs-mdx:collections/server';
 import { type InferPageType, loader } from 'fumadocs-core/source';
 import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
 import { toFumadocsSource } from 'fumadocs-mdx/runtime/server';
+import { i18n } from '@/lib/i18n';
 
 // See https://fumadocs.dev/docs/headless/source-api for more info
 export const source = loader({
   baseUrl: '/docs',
   source: docs.toFumadocsSource(),
   plugins: [lucideIconsPlugin()],
+  i18n,
 });
 
 export function getPageImage(page: InferPageType<typeof source>) {
@@ -30,8 +32,9 @@ export const news = loader({
 });
 
 export function getAvailableYears(): string[] {
-  return source.pageTree.children
-    .filter(
+  return source
+    .getPageTree()
+    .children.filter(
       (node): node is typeof node & { name: string } =>
         node.type === 'folder' &&
         typeof node.name === 'string' &&

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "knip": "knip"
   },
   "dependencies": {
+    "@orama/tokenizers": "^3.1.18",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@orama/tokenizers':
+        specifier: ^3.1.18
+        version: 3.1.18
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -783,6 +786,10 @@ packages:
 
   '@orama/orama@3.1.18':
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
+    engines: {node: '>= 20.0.0'}
+
+  '@orama/tokenizers@3.1.18':
+    resolution: {integrity: sha512-Ra4dFddWZ7hCGPAehnd/6QZjlzQvczYSt1y1Fq4HteJqRu2yvfR6fXvxiUnKi+HIgJYPxKhebJEjvJdF8LYQWg==}
     engines: {node: '>= 20.0.0'}
 
   '@oxc-resolver/binding-android-arm-eabi@11.17.0':
@@ -4547,6 +4554,10 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@orama/orama@3.1.18': {}
+
+  '@orama/tokenizers@3.1.18':
+    dependencies:
+      '@orama/orama': 3.1.18
 
   '@oxc-resolver/binding-android-arm-eabi@11.17.0':
     optional: true


### PR DESCRIPTION
With fumadocs i18n configured, `pageTree` is `Record<string, Root>` (locale → tree), so it has no `.children` array and `source.pageTree.children` caused a type error.

**Changes:**
- `app/docs/[year]/layout.tsx`: use `source.getPageTree()` to get the Root, then `pageTree.children.find(...)`
- `lib/source.tsx`: `getAvailableYears()` uses `source.getPageTree().children` instead of `source.pageTree.children`

Made with [Cursor](https://cursor.com)