### PR TITLE
fix: use sizes='100vw' for better image quality in landing page

### DIFF
--- a/app/(home)/blog/page.tsx
+++ b/app/(home)/blog/page.tsx
@@ -70,7 +70,7 @@ export default function Page() {
       <div className="dark relative z-2 mb-4 aspect-[3.2] p-8 md:p-12">
         <Image
           src={BannerImage}
-          priority
+          loading="eager"
           alt="banner"
           className="absolute inset-0 -z-1 size-full object-cover"
         />

--- a/app/(home)/news/page.tsx
+++ b/app/(home)/news/page.tsx
@@ -70,7 +70,7 @@ export default function Page() {
       <div className="dark relative z-2 mb-4 aspect-[3.2] p-8 md:p-12">
         <Image
           src={BannerImage}
-          priority
+          loading="eager"
           alt="banner"
           className="absolute inset-0 -z-1 size-full object-cover"
         />

--- a/components/hero-cards.tsx
+++ b/components/hero-cards.tsx
@@ -37,6 +37,7 @@ function HeroCard({ linkTo, content, imageURL, index }: HeroCardProps) {
           fill
           className="object-cover object-top"
           sizes="100vw"
+          loading="eager"
         />
       </div>
     </Link>
@@ -52,7 +53,7 @@ function MobileLogo() {
         width={280}
         height={160}
         className="h-auto w-70 dark:opacity-90 dark:brightness-110"
-        priority
+        loading="eager"
       />
     </div>
   );


### PR DESCRIPTION
- Use a higher `sizes` value to prevent the blurry images
- Use loading to replace deprecated priority

Note: can use https://www.framer.com/marketplace/components/photo-card/ in the future to have a better UX and load animation 