### PR TITLE
fix(news): sort weekly posts by latest date first

### DIFF
--- a/app/(home)/news/[...slug]/page.tsx
+++ b/app/(home)/news/[...slug]/page.tsx
@@ -24,7 +24,7 @@ export default async function Page(props: {
           const wb = b.data.weight ?? Infinity;
           if (wa !== wb) return wa - wb;
           return (
-            new Date(a.data.date).getTime() - new Date(b.data.date).getTime()
+            new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
           );
         })
     : [];


### PR DESCRIPTION
## Description

Fix the sorting order for weekly news posts to display from latest to oldest instead of oldest to latest.

The comparison logic was inverted:
- Before: `new Date(a).getTime() - new Date(b).getTime()` (ascending - oldest first)
- After: `new Date(b).getTime() - new Date(a).getTime()` (descending - latest first)

This ensures that when viewing `/news/weekly`, the most recent weekly posts are shown first.

## Test

- Manually verified the sorting logic change produces the correct order
- TypeScript checks passed

Refs #96
