### PR TITLE
chore: streamline local tooling setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,37 +27,10 @@ jobs:
           repository: ${{ github.repository }}
           ref: main
 
-      - name: Fetch blog and news content
-        run: |
-          rm -rf content/blog content/news
-          for type in blog news; do
-            git clone --depth 1 --filter=blob:none https://github.com/HITSZ-OpenAuto/hoa-$type temp
-            mv temp/$type content/$type
-            rm -rf temp
-          done
-
-      - name: Clone hoa-major-data
-        run: git clone https://github.com/HITSZ-OpenAuto/hoa-major-data
-
-      - name: Fetch repositories in the organization
-        run: curl -o repos_list.txt https://raw.githubusercontent.com/HITSZ-OpenAuto/repos-management/refs/heads/main/repos_list.txt
-
-      - name: Download and Setup hoa-backend
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download --repo HITSZ-OpenAuto/hoa-backend --pattern "hoa-backend-linux.tar.gz"
-          tar -xzf hoa-backend-linux.tar.gz
-          chmod +x hoa-backend
-          sudo mv hoa-backend /usr/local/bin/
-          rm hoa-backend-linux.tar.gz
-
-      - name: Build course pages
+      - name: Build content
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          rm -rf content/docs
-          hoa-backend --fetch
+        run: make content
 
       - name: Check for changes
         id: check_changes
@@ -145,10 +118,7 @@ jobs:
         run: pnpm run knip
 
       - name: Fetch external data
-        run: |
-          curl -o repos_list.txt https://raw.githubusercontent.com/HITSZ-OpenAuto/repos-management/refs/heads/main/repos_list.txt
-          mkdir -p hoa-major-data
-          curl -o hoa-major-data/major_mapping.json https://raw.githubusercontent.com/HITSZ-OpenAuto/hoa-major-data/main/major_mapping.json
+        run: ./scripts/fetch-data.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,37 +22,10 @@ jobs:
           repository: ${{ github.repository }}
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Fetch blog and news content
-        run: |
-          rm -rf content/blog content/news
-          for type in blog news; do
-            git clone --depth 1 --filter=blob:none https://github.com/HITSZ-OpenAuto/hoa-$type temp
-            mv temp/$type content/$type
-            rm -rf temp
-          done
-
-      - name: Fetch repositories in the organization
-        run: curl -o repos_list.txt https://raw.githubusercontent.com/HITSZ-OpenAuto/repos-management/refs/heads/main/repos_list.txt
-
-      - name: Clone hoa-major-data
-        run: git clone https://github.com/HITSZ-OpenAuto/hoa-major-data
-
-      - name: Download and Setup hoa-backend
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download --repo HITSZ-OpenAuto/hoa-backend --pattern "hoa-backend-linux.tar.gz"
-          tar -xzf hoa-backend-linux.tar.gz
-          chmod +x hoa-backend
-          sudo mv hoa-backend /usr/local/bin/
-
-          rm hoa-backend-linux.tar.gz
-
-      - name: Build course pages
+      - name: Build content
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          hoa-backend --fetch
+        run: make content
 
       - uses: pnpm/action-setup@v6
         name: Install pnpm

--- a/.gitignore
+++ b/.gitignore
@@ -41,11 +41,9 @@ next-env.d.ts
 
 # artifacts
 repos/
-repos_list.txt
+lib/data/
+.tools/
 scripts/.env
-
-# local clones
-hoa-major-data/
 
 # secrets
 .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+## Project overview
+
+- Next.js/Fumadocs frontend for HOA project.
+- Use `pnpm` for Node commands.
+
+## Setup and development
+
+- Install dependencies and local tools/data: `make prepare`
+- Fetch content: `make content`
+- Start dev server: `make dev`
+- Clean generated local state: `make clean`
+
+`make prepare` downloads frontend data into `lib/data/` and installs `hoa-backend` into `.tools/bin/`; it must not install Cargo packages or write to global user bins.
+
+## Checks
+
+Before finishing changes, run:
+
+```bash
+make check
+```

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ knip:
 check: lint format type-check knip
 
 clean:
-	rm -rf node_modules .next .source .tools
+	rm -rf node_modules .next .source .tools lib/data
 
 content:
 	./scripts/fetch-data.sh

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PM := pnpm
 help:
 	@printf "%s\n" \
 		"Targets:" \
-		"  prepare                 Install deps and hoa-backend" \
+		"  prepare                 Install deps and local tools/data" \
 		"  dev                     Launch the frontend dev server" \
 		"  build                   Build the frontend" \
 		"  start                   Start the built frontend (production)" \
@@ -14,25 +14,14 @@ help:
 		"  type-check              Run type checks" \
 		"  knip                    Run knip" \
 		"  check                   Run lint, format, type checks, and knip" \
-		"  clean                   Remove node_modules, .next, .source" \
-		"  content                 Fetch blog and news content" \
+		"  clean                   Remove generated dependencies, builds, and local tools" \
+		"  content                 Fetch blog, news, and docs content" \
 		"  ignore-content-changes  Tell Git to ignore local changes under content/ (run once per clone)"
 
 prepare:
 	$(PM) install
-	test -d hoa-major-data || git clone https://github.com/HITSZ-OpenAuto/hoa-major-data
-	@if [ "$$(uname -s)" = "Darwin" ] && [ "$$(uname -m)" = "arm64" ]; then \
-		echo "Downloading hoa-backend binary for macOS-arm64..."; \
-		mkdir -p $(HOME)/.cargo/bin; \
-		curl -L https://github.com/HITSZ-OpenAuto/hoa-backend/releases/latest/download/hoa-backend-macos-arm64.tar.gz | tar -xz -C $(HOME)/.cargo/bin; \
-	elif [ "$$(uname -s)" = "Linux" ] && [ "$$(uname -m)" = "x86_64" ]; then \
-		echo "Downloading hoa-backend binary for Linux..."; \
-		mkdir -p $(HOME)/.cargo/bin; \
-		curl -L https://github.com/HITSZ-OpenAuto/hoa-backend/releases/latest/download/hoa-backend-linux.tar.gz | tar -xz -C $(HOME)/.cargo/bin; \
-	else \
-		cargo install --git https://github.com/HITSZ-OpenAuto/hoa-backend.git; \
-	fi
-	curl -o repos_list.txt https://raw.githubusercontent.com/HITSZ-OpenAuto/repos-management/refs/heads/main/repos_list.txt
+	./scripts/fetch-data.sh
+	./scripts/install-hoa-backend.sh
 
 dev:
 	$(PM) run dev
@@ -58,16 +47,12 @@ knip:
 check: lint format type-check knip
 
 clean:
-	rm -rf node_modules .next .source
+	rm -rf node_modules .next .source .tools
 
 content:
-	rm -rf content/blog content/news content/docs
-	for type in blog news; do \
-		git clone --depth 1 --filter=blob:none https://github.com/HITSZ-OpenAuto/hoa-$$type temp; \
-		mv temp/$$type content/$$type; \
-		rm -rf temp; \
-	done
-	hoa-backend --fetch
+	./scripts/fetch-data.sh
+	./scripts/install-hoa-backend.sh
+	./scripts/fetch-content.sh
 	$(MAKE) ignore-content-changes
 
 ignore-content-changes:

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ knip:
 check: lint format type-check knip
 
 clean:
-	rm -rf node_modules .next .source .tools lib/data
+	rm -rf node_modules .pnpm-store .next .source out build coverage .tools lib/data content repos *.tsbuildinfo
 
 content:
 	./scripts/fetch-data.sh

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ The framework for building courses-sharing platform, built by [HOA](https://gith
 ## Getting Started
 
 ```bash
-make prepare
-make content
+make prepare # minimal frontend setup
+make content # fetch full HOA content
+make dev # start dev
 ```
 
 ## Contributing

--- a/lib/docs.ts
+++ b/lib/docs.ts
@@ -1,5 +1,5 @@
 import { source } from '@/lib/source';
-import majorMapping from '@/hoa-major-data/major_mapping.json';
+import majorMapping from '@/lib/data/major_mapping.json';
 import { cache } from 'react';
 import { computeYearMajorMap, MajorEntry } from './docs-utils';
 

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { GITHUB_ORG } from './constants';
 
-const REPOS_FILE = path.join(process.cwd(), 'repos_list.txt');
+const REPOS_FILE = path.join(process.cwd(), 'lib/data/repos_list.txt');
 
 type RepoItem = {
   id: string;

--- a/scripts/fetch-content.sh
+++ b/scripts/fetch-content.sh
@@ -5,9 +5,15 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
 hoa_backend="${HOA_BACKEND:-$repo_root/.tools/bin/hoa-backend}"
+repos_list="$repo_root/lib/data/repos_list.txt"
 major_data_archive="https://github.com/HITSZ-OpenAuto/hoa-major-data/archive/refs/heads/main.tar.gz"
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir" temp' EXIT
+
+if [ ! -r "$repos_list" ]; then
+  echo "Missing $repos_list. Run ./scripts/fetch-data.sh first." >&2
+  exit 1
+fi
 
 rm -rf content/blog content/news content/docs
 for type in blog news; do
@@ -20,7 +26,7 @@ done
 curl -fsSL "$major_data_archive" | tar -xz -C "$workdir"
 mv "$workdir/hoa-major-data-main" "$workdir/hoa-major-data"
 ln -s "$repo_root/content" "$workdir/content"
-ln -s "$repo_root/lib/data/repos_list.txt" "$workdir/repos_list.txt"
+ln -s "$repos_list" "$workdir/repos_list.txt"
 
 (
   cd "$workdir"

--- a/scripts/fetch-content.sh
+++ b/scripts/fetch-content.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+hoa_backend="${HOA_BACKEND:-$repo_root/.tools/bin/hoa-backend}"
+major_data_archive="https://github.com/HITSZ-OpenAuto/hoa-major-data/archive/refs/heads/main.tar.gz"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir" temp' EXIT
+
+rm -rf content/blog content/news content/docs
+for type in blog news; do
+  rm -rf temp
+  git clone --depth 1 --filter=blob:none "https://github.com/HITSZ-OpenAuto/hoa-${type}" temp
+  mv "temp/${type}" "content/${type}"
+  rm -rf temp
+done
+
+curl -fsSL "$major_data_archive" | tar -xz -C "$workdir"
+mv "$workdir/hoa-major-data-main" "$workdir/hoa-major-data"
+ln -s "$repo_root/content" "$workdir/content"
+ln -s "$repo_root/lib/data/repos_list.txt" "$workdir/repos_list.txt"
+
+(
+  cd "$workdir"
+  "$hoa_backend" --fetch
+)

--- a/scripts/fetch-content.sh
+++ b/scripts/fetch-content.sh
@@ -16,6 +16,7 @@ if [ ! -r "$repos_list" ]; then
 fi
 
 rm -rf content/blog content/news content/docs
+mkdir -p content
 for type in blog news; do
   rm -rf temp
   git clone --depth 1 --filter=blob:none "https://github.com/HITSZ-OpenAuto/hoa-${type}" temp

--- a/scripts/fetch-data.sh
+++ b/scripts/fetch-data.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+mkdir -p lib/data
+
+curl -fsSL \
+  -o lib/data/major_mapping.json \
+  https://raw.githubusercontent.com/HITSZ-OpenAuto/hoa-major-data/main/major_mapping.json
+
+curl -fsSL \
+  -o lib/data/repos_list.txt \
+  https://raw.githubusercontent.com/HITSZ-OpenAuto/repos-management/refs/heads/main/repos_list.txt

--- a/scripts/install-hoa-backend.sh
+++ b/scripts/install-hoa-backend.sh
@@ -5,7 +5,12 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
 tools_dir="${HOA_TOOLS_DIR:-.tools/bin}"
+hoa_backend="$tools_dir/hoa-backend"
 mkdir -p "$tools_dir"
+
+if [ -x "$hoa_backend" ]; then
+  exit 0
+fi
 
 case "$(uname -s)-$(uname -m)" in
   Darwin-arm64)
@@ -22,4 +27,4 @@ case "$(uname -s)-$(uname -m)" in
 esac
 
 curl -fsSL "$archive_url" | tar -xz -C "$tools_dir"
-chmod +x "$tools_dir/hoa-backend"
+chmod +x "$hoa_backend"

--- a/scripts/install-hoa-backend.sh
+++ b/scripts/install-hoa-backend.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+tools_dir="${HOA_TOOLS_DIR:-.tools/bin}"
+mkdir -p "$tools_dir"
+
+case "$(uname -s)-$(uname -m)" in
+  Darwin-arm64)
+    archive_url="https://github.com/HITSZ-OpenAuto/hoa-backend/releases/latest/download/hoa-backend-macos-arm64.tar.gz"
+    ;;
+  Linux-x86_64)
+    archive_url="https://github.com/HITSZ-OpenAuto/hoa-backend/releases/latest/download/hoa-backend-linux.tar.gz"
+    ;;
+  *)
+    echo "Unsupported platform: $(uname -s)-$(uname -m)" >&2
+    echo "Please download hoa-backend manually into $tools_dir/hoa-backend." >&2
+    exit 1
+    ;;
+esac
+
+curl -fsSL "$archive_url" | tar -xz -C "$tools_dir"
+chmod +x "$tools_dir/hoa-backend"


### PR DESCRIPTION
## Description

- Replace local `hoa-major-data` clones with generated `lib/data` artifacts.
- Install `hoa-backend` into project-local `.tools/bin` instead of global Cargo/user bins.
- Move reusable setup/content logic into scripts and reuse `make content` in CI.
- Add a concise `AGENTS.md` for agent setup and development guidance.

## Type of change

- [x] Enhancement
- [x] Documentation update

## Test

- [x] `make check`

---

Assisted-by: pi
