### PR TITLE
perf: optimize docs compile and search

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,6 +2,8 @@ name: Preview
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -59,12 +61,80 @@ jobs:
 
       - name: Build Project Artifacts
         if: ${{ env.VERCEL_TOKEN != '' }}
-        run: vercel build --token=${{ env.VERCEL_TOKEN }}
+        run: vercel build --target=preview --token=${{ env.VERCEL_TOKEN }}
 
       - name: Build Project Artifacts (no Vercel token)
         if: ${{ env.VERCEL_TOKEN == '' }}
         run: pnpm run build
 
       - name: Deploy Preview to Vercel
+        id: deploy
         if: ${{ env.VERCEL_TOKEN != '' }}
-        run: vercel deploy --prebuilt --token=${{ env.VERCEL_TOKEN }} --archive=tgz
+        run: |
+          set -o pipefail
+          vercel deploy --prebuilt --target=preview --token=${{ env.VERCEL_TOKEN }} --archive=tgz 2>&1 | tee deployment.log
+          node --input-type=module <<'JS' >> "$GITHUB_OUTPUT"
+          import { readFileSync } from 'node:fs';
+
+          const log = readFileSync('deployment.log', 'utf8').replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, '');
+          const inspectUrl = [...log.matchAll(/https:\/\/vercel\.com\/\S+/g)].at(-1)?.[0];
+          const previewUrl = [...log.matchAll(/https:\/\/[^\s)]+\.vercel\.app/g)].at(-1)?.[0];
+          if (!inspectUrl || !previewUrl) {
+            throw new Error(`Unable to extract Vercel URLs. inspect=${inspectUrl ?? '<missing>'} preview=${previewUrl ?? '<missing>'}`);
+          }
+          console.log(`inspect_url=${inspectUrl}`);
+          console.log(`preview_url=${previewUrl}`);
+          JS
+
+      - name: Comment Preview URL
+        if: ${{ env.VERCEL_TOKEN != '' && steps.deploy.outputs.preview_url != '' }}
+        env:
+          INSPECT_URL: ${{ steps.deploy.outputs.inspect_url }}
+          PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
+          COMMENT_TOKEN: ${{ github.token }}
+        run: |
+          node --input-type=module <<'JS'
+          import { readFileSync } from 'node:fs';
+
+          const marker = '<!-- hoa-fuma-vercel-preview -->';
+          const updated = new Date().toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, ' UTC');
+          const body = [
+            marker,
+            'The latest updates on your projects.',
+            '',
+            '| Project | Deployment | Actions | Updated (UTC) |',
+            '| --- | --- | --- | --- |',
+            `| hoa-fuma | Ready | [Preview](${process.env.PREVIEW_URL}), [Inspect](${process.env.INSPECT_URL}) | ${updated} |`,
+          ].join('\n');
+          const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+          const event = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+          const issueNumber = event.pull_request.number;
+          const headers = {
+            Authorization: `Bearer ${process.env.COMMENT_TOKEN}`,
+            Accept: 'application/vnd.github+json',
+            'Content-Type': 'application/json',
+            'X-GitHub-Api-Version': '2022-11-28',
+          };
+          const api = 'https://api.github.com';
+          const commentsUrl = `${api}/repos/${owner}/${repo}/issues/${issueNumber}/comments`;
+          const request = async (url, options = {}) => {
+            const response = await fetch(url, { ...options, headers: { ...headers, ...options.headers } });
+            if (!response.ok) {
+              throw new Error(`${options.method ?? 'GET'} ${url} failed with ${response.status}: ${await response.text()}`);
+            }
+            return response.status === 204 ? null : response.json();
+          };
+          const comments = await request(`${commentsUrl}?per_page=100`);
+          const comment = comments.find((item) => item.body.includes(marker));
+          if (comment) {
+            await request(`${api}/repos/${owner}/${repo}/issues/comments/${comment.id}`, {
+              method: 'PATCH',
+              body: JSON.stringify({ body }),
+            });
+          } else {
+            await request(commentsUrl, {
+              method: 'POST',
+              body: JSON.stringify({ body }),
+            });
+          }
+          JS

--- a/app/(home)/blog/[...slug]/page.tsx
+++ b/app/(home)/blog/[...slug]/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { getMDXComponents } from '@/components/mdx';
 import { blog } from '@/lib/source/posts';
 import { formatDate } from '@/lib/utils';
+import { getPostSummaries, getSeriesPosts } from '@/lib/posts-summary';
 
 export default async function Page(props: {
   params: Promise<{ slug: string[] }>;
@@ -15,19 +16,7 @@ export default async function Page(props: {
   if (!page) notFound();
   const isSeriesIndex = page.slugs.length === 1;
   const seriesPosts = isSeriesIndex
-    ? blog
-        .getPages()
-        .filter(
-          (post) => post.slugs.length > 1 && post.slugs[0] === page.slugs[0]
-        )
-        .sort((a, b) => {
-          const wa = a.data.weight ?? Infinity;
-          const wb = b.data.weight ?? Infinity;
-          if (wa !== wb) return wa - wb;
-          return (
-            new Date(a.data.date).getTime() - new Date(b.data.date).getTime()
-          );
-        })
+    ? getSeriesPosts('blog', page.slugs[0])
     : [];
   const Mdx = page.data.body;
   const toc = page.data.toc;
@@ -46,12 +35,12 @@ export default async function Page(props: {
               href={post.url}
               className="bg-fd-card hover:bg-fd-accent hover:text-fd-accent-foreground flex flex-col rounded-2xl border p-4 shadow-sm transition-colors"
             >
-              <p className="font-medium">{post.data.title}</p>
+              <p className="font-medium">{post.title}</p>
               <p className="text-fd-muted-foreground text-sm">
-                {post.data.description}
+                {post.description}
               </p>
               <p className="text-brand mt-auto pt-4 text-xs">
-                {formatDate(post.data.date)}
+                {formatDate(post.date)}
               </p>
             </Link>
           ))}
@@ -124,7 +113,7 @@ export default async function Page(props: {
 }
 
 export function generateStaticParams(): { slug: string[] }[] {
-  return blog.getPages().map((page) => ({
+  return getPostSummaries('blog').map((page) => ({
     slug: page.slugs,
   }));
 }

--- a/app/(home)/blog/[...slug]/page.tsx
+++ b/app/(home)/blog/[...slug]/page.tsx
@@ -3,7 +3,7 @@ import { InlineTOC } from 'fumadocs-ui/components/inline-toc';
 import Image from 'next/image';
 import Link from 'next/link';
 import { getMDXComponents } from '@/components/mdx';
-import { blog } from '@/lib/source';
+import { blog } from '@/lib/source/posts';
 import { formatDate } from '@/lib/utils';
 
 export default async function Page(props: {

--- a/app/(home)/blog/page.tsx
+++ b/app/(home)/blog/page.tsx
@@ -1,68 +1,10 @@
 import Link from 'next/link';
-import { blog } from '@/lib/source/posts';
 import Image from 'next/image';
 import { formatDate } from '@/lib/utils';
+import { getPostListItems } from '@/lib/posts-summary';
 
 export default function Page() {
-  const pages = blog.getPages();
-  const seriesMap = new Map<
-    string,
-    {
-      index?: (typeof pages)[number];
-      posts: (typeof pages)[number][];
-    }
-  >();
-
-  for (const page of pages) {
-    const seriesSlug = page.slugs[0];
-    if (!seriesSlug) continue;
-    const series = seriesMap.get(seriesSlug) ?? { posts: [] };
-    if (page.slugs.length === 1) {
-      series.index = page;
-    } else {
-      series.posts.push(page);
-    }
-    seriesMap.set(seriesSlug, series);
-  }
-
-  const seriesItems = [...seriesMap.entries()]
-    .filter(([, entry]) => entry.posts.length > 0)
-    .map(([slug, entry]) => {
-      const dates = [
-        entry.index?.data.date,
-        ...entry.posts.map((post) => post.data.date),
-      ]
-        .filter(Boolean)
-        .map((date) => new Date(date as string | Date).getTime());
-      const latestDate = dates.length > 0 ? new Date(Math.max(...dates)) : null;
-      return {
-        type: 'series' as const,
-        slug,
-        title: entry.index?.data.title ?? slug,
-        description: entry.index?.data.description ?? '',
-        date: latestDate,
-      };
-    });
-
-  const seriesSlugs = new Set(seriesItems.map((item) => item.slug));
-  const postItems = pages
-    .filter(
-      (page) => page.slugs.length === 1 && !seriesSlugs.has(page.slugs[0])
-    )
-    .map((post) => ({
-      type: 'post' as const,
-      slug: post.slugs[0],
-      title: post.data.title,
-      description: post.data.description,
-      date: new Date(post.data.date),
-      url: post.url,
-    }));
-
-  const items = [...seriesItems, ...postItems].sort((a, b) => {
-    const aDate = a.date?.getTime() ?? 0;
-    const bDate = b.date?.getTime() ?? 0;
-    return bDate - aDate;
-  });
+  const items = getPostListItems('blog');
 
   return (
     <main className="max-w-page mx-auto w-full px-4 pb-12 md:py-12">

--- a/app/(home)/blog/page.tsx
+++ b/app/(home)/blog/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { blog } from '@/lib/source';
+import { blog } from '@/lib/source/posts';
 import Image from 'next/image';
 import { formatDate } from '@/lib/utils';
 

--- a/app/(home)/news/[...slug]/page.tsx
+++ b/app/(home)/news/[...slug]/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { getMDXComponents } from '@/components/mdx';
 import { news } from '@/lib/source/posts';
 import { formatDate } from '@/lib/utils';
+import { getPostSummaries, getSeriesPosts } from '@/lib/posts-summary';
 
 export default async function Page(props: {
   params: Promise<{ slug: string[] }>;
@@ -14,19 +15,7 @@ export default async function Page(props: {
   if (!page) notFound();
   const isSeriesIndex = page.slugs.length === 1;
   const seriesPosts = isSeriesIndex
-    ? news
-        .getPages()
-        .filter(
-          (post) => post.slugs.length > 1 && post.slugs[0] === page.slugs[0]
-        )
-        .sort((a, b) => {
-          const wa = a.data.weight ?? Infinity;
-          const wb = b.data.weight ?? Infinity;
-          if (wa !== wb) return wa - wb;
-          return (
-            new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
-          );
-        })
+    ? getSeriesPosts('news', page.slugs[0])
     : [];
   const Mdx = page.data.body;
 
@@ -44,12 +33,12 @@ export default async function Page(props: {
               href={post.url}
               className="bg-fd-card hover:bg-fd-accent hover:text-fd-accent-foreground flex flex-col rounded-2xl border p-4 shadow-sm transition-colors"
             >
-              <p className="font-medium">{post.data.title}</p>
+              <p className="font-medium">{post.title}</p>
               <p className="text-fd-muted-foreground text-sm">
-                {post.data.description}
+                {post.description}
               </p>
               <p className="text-brand mt-auto pt-4 text-xs">
-                {formatDate(post.data.date)}
+                {formatDate(post.date)}
               </p>
             </Link>
           ))}
@@ -121,7 +110,7 @@ export default async function Page(props: {
 }
 
 export function generateStaticParams(): { slug: string[] }[] {
-  return news.getPages().map((page) => ({
+  return getPostSummaries('news').map((page) => ({
     slug: page.slugs,
   }));
 }

--- a/app/(home)/news/[...slug]/page.tsx
+++ b/app/(home)/news/[...slug]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
 import { getMDXComponents } from '@/components/mdx';
-import { news } from '@/lib/source';
+import { news } from '@/lib/source/posts';
 import { formatDate } from '@/lib/utils';
 
 export default async function Page(props: {

--- a/app/(home)/news/page.tsx
+++ b/app/(home)/news/page.tsx
@@ -1,68 +1,10 @@
 import Link from 'next/link';
-import { news } from '@/lib/source/posts';
 import Image from 'next/image';
 import { formatDate } from '@/lib/utils';
+import { getPostListItems } from '@/lib/posts-summary';
 
 export default function Page() {
-  const pages = news.getPages();
-  const seriesMap = new Map<
-    string,
-    {
-      index?: (typeof pages)[number];
-      posts: (typeof pages)[number][];
-    }
-  >();
-
-  for (const page of pages) {
-    const seriesSlug = page.slugs[0];
-    if (!seriesSlug) continue;
-    const series = seriesMap.get(seriesSlug) ?? { posts: [] };
-    if (page.slugs.length === 1) {
-      series.index = page;
-    } else {
-      series.posts.push(page);
-    }
-    seriesMap.set(seriesSlug, series);
-  }
-
-  const seriesItems = [...seriesMap.entries()]
-    .filter(([, entry]) => entry.posts.length > 0)
-    .map(([slug, entry]) => {
-      const dates = [
-        entry.index?.data.date,
-        ...entry.posts.map((post) => post.data.date),
-      ]
-        .filter(Boolean)
-        .map((date) => new Date(date as string | Date).getTime());
-      const latestDate = dates.length > 0 ? new Date(Math.max(...dates)) : null;
-      return {
-        type: 'series' as const,
-        slug,
-        title: entry.index?.data.title ?? slug,
-        description: entry.index?.data.description ?? '',
-        date: latestDate,
-      };
-    });
-
-  const seriesSlugs = new Set(seriesItems.map((item) => item.slug));
-  const postItems = pages
-    .filter(
-      (page) => page.slugs.length === 1 && !seriesSlugs.has(page.slugs[0])
-    )
-    .map((post) => ({
-      type: 'post' as const,
-      slug: post.slugs[0],
-      title: post.data.title,
-      description: post.data.description,
-      date: new Date(post.data.date),
-      url: post.url,
-    }));
-
-  const items = [...seriesItems, ...postItems].sort((a, b) => {
-    const aDate = a.date?.getTime() ?? 0;
-    const bDate = b.date?.getTime() ?? 0;
-    return bDate - aDate;
-  });
+  const items = getPostListItems('news');
 
   return (
     <main className="max-w-page mx-auto w-full px-4 pb-12 md:py-12">

--- a/app/(home)/news/page.tsx
+++ b/app/(home)/news/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { news } from '@/lib/source';
+import { news } from '@/lib/source/posts';
 import Image from 'next/image';
 import { formatDate } from '@/lib/utils';
 

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -1,6 +1,6 @@
+import { Suspense } from 'react';
 import { Mail } from 'lucide-react';
 import localFont from 'next/font/local';
-import { siGithub } from 'simple-icons';
 import { RecentRepos } from '@/components/recent-repos';
 import { ScrollHint } from '@/components/scroll-hint';
 import { LatestPosts } from '@/components/latest-posts';
@@ -8,12 +8,15 @@ import { HeroCards } from '@/components/hero-cards';
 import { HeroButtons } from '@/components/hero-buttons';
 import { Button } from '@/components/ui/button';
 import { getRecentRepos } from '@/lib/github';
-import { getYearMajorMap } from '@/lib/docs';
+import { getYearMajorMap } from '@/lib/docs-home';
 
 const wordmark = localFont({
   src: '../../public/fonts/zalando-sans-expanded-latin-500.woff2',
   adjustFontFallback: false,
 });
+
+const githubPath =
+  'M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.725-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12';
 
 function HeroContent() {
   const yearMajorMap = getYearMajorMap();
@@ -37,9 +40,13 @@ function HeroContent() {
   );
 }
 
-export default async function HomePage() {
+async function RecentReposSection() {
   const recentRepos = await getRecentRepos(3);
 
+  return <RecentRepos repos={recentRepos} title="最近更新的仓库" />;
+}
+
+export default function HomePage() {
   return (
     <div className="bg-background text-foreground relative min-h-svh">
       {/* Hero section */}
@@ -61,7 +68,9 @@ export default async function HomePage() {
 
       {/* Recent updates section */}
       <div className="relative px-6">
-        <RecentRepos repos={recentRepos} title="最近更新的仓库" />
+        <Suspense fallback={null}>
+          <RecentReposSection />
+        </Suspense>
         <LatestPosts />
       </div>
 
@@ -96,7 +105,7 @@ export default async function HomePage() {
                   className="h-4 w-4"
                   aria-hidden="true"
                 >
-                  <path d={siGithub.path} />
+                  <path d={githubPath} />
                 </svg>
                 GitHub
               </a>

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,18 +1,25 @@
-import { source } from '@/lib/source/docs';
-import { createFromSource } from 'fumadocs-core/search/server';
-import { createTokenizer } from '@orama/tokenizers/mandarin';
+import { searchDocs } from '@/lib/search-index';
 
-export const { GET } = createFromSource(source, {
-  localeMap: {
-    // [locale]: Orama options
-    cn: {
-      components: {
-        tokenizer: createTokenizer(),
+export const dynamic = 'force-dynamic';
+
+export function GET(request: Request) {
+  const url = new URL(request.url);
+  const query = url.searchParams.get('query');
+  const locale = url.searchParams.get('locale');
+  const limit = url.searchParams.has('limit')
+    ? Number(url.searchParams.get('limit'))
+    : undefined;
+
+  if (!query || (locale && locale !== 'cn')) {
+    return Response.json([]);
+  }
+
+  return Response.json(
+    searchDocs(query, Number.isInteger(limit) ? limit : 60),
+    {
+      headers: {
+        'Cache-Control': 'no-store',
       },
-      search: {
-        threshold: 0,
-        tolerance: 0,
-      },
-    },
-  },
-});
+    }
+  );
+}

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -13,13 +13,14 @@ export function GET(request: Request) {
   if (!query || (locale && locale !== 'cn')) {
     return Response.json([]);
   }
+  const resultLimit =
+    typeof limit === 'number' && Number.isInteger(limit) && limit > 0
+      ? limit
+      : 60;
 
-  return Response.json(
-    searchDocs(query, Number.isInteger(limit) ? limit : 60),
-    {
-      headers: {
-        'Cache-Control': 'no-store',
-      },
-    }
-  );
+  return Response.json(searchDocs(query, resultLimit), {
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+  });
 }

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,4 +1,4 @@
-import { source } from '@/lib/source';
+import { source } from '@/lib/source/docs';
 import { createFromSource } from 'fumadocs-core/search/server';
 import { createTokenizer } from '@orama/tokenizers/mandarin';
 

--- a/app/docs/[year]/[[...slug]]/page.tsx
+++ b/app/docs/[year]/[[...slug]]/page.tsx
@@ -15,7 +15,7 @@ import { PageActions } from '@/components/page-actions';
 import { cookies } from 'next/headers';
 import { findRedirect } from '@/lib/redirect';
 import { isYear } from '@/lib/utils';
-import { getMDXComponents } from '@/components/mdx';
+import { getMDXComponents, NoPrefetchLink } from '@/components/mdx';
 
 export default async function Page(props: {
   params: Promise<{ year: string; slug?: string[] }>;
@@ -66,7 +66,7 @@ export default async function Page(props: {
         <MDX
           components={getMDXComponents(
             {
-              a: createRelativeLink(source, page),
+              a: createRelativeLink(source, page, NoPrefetchLink),
             },
             {
               course: page.data.course,

--- a/app/docs/[year]/[[...slug]]/page.tsx
+++ b/app/docs/[year]/[[...slug]]/page.tsx
@@ -1,4 +1,4 @@
-import { getPageImage, source } from '@/lib/source';
+import { getPageImage, source } from '@/lib/source/docs';
 import {
   DocsBody,
   DocsDescription,
@@ -36,7 +36,8 @@ export default async function Page(props: {
   const page = source.getPage([params.year, ...(params.slug ?? [])]);
   if (!page) notFound();
 
-  const MDX = page.data.body;
+  const pageBody = await page.data.load();
+  const MDX = pageBody.body;
 
   // For course pages, extract repo name from the last slug segment
   const repoName = page.data.course ? (params.slug?.at(-1) ?? null) : null;
@@ -47,7 +48,7 @@ export default async function Page(props: {
     : null;
 
   return (
-    <DocsPage toc={page.data.toc} full={page.data.full}>
+    <DocsPage toc={pageBody.toc} full={page.data.full}>
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription className="mb-0 text-base">
         {latestCommit ? (

--- a/app/docs/[year]/[[...slug]]/page.tsx
+++ b/app/docs/[year]/[[...slug]]/page.tsx
@@ -16,6 +16,7 @@ import { cookies } from 'next/headers';
 import { findRedirect } from '@/lib/redirect';
 import { isYear } from '@/lib/utils';
 import { getMDXComponents, NoPrefetchLink } from '@/components/mdx';
+import { getDocsCourse } from '@/lib/course-frontmatter';
 
 export default async function Page(props: {
   params: Promise<{ year: string; slug?: string[] }>;
@@ -33,14 +34,15 @@ export default async function Page(props: {
     notFound();
   }
 
-  const page = source.getPage([params.year, ...(params.slug ?? [])]);
+  const segments = [params.year, ...(params.slug ?? [])];
+  const page = source.getPage(segments);
   if (!page) notFound();
 
   const pageBody = await page.data.load();
   const MDX = pageBody.body;
 
-  // For course pages, extract repo name from the last slug segment
-  const repoName = page.data.course ? (params.slug?.at(-1) ?? null) : null;
+  const course = getDocsCourse(segments);
+  const repoName = course ? (params.slug?.at(-1) ?? null) : null;
   const latestCommit = repoName ? await getLatestCommit(repoName) : null;
 
   const githubUrl = repoName
@@ -69,7 +71,7 @@ export default async function Page(props: {
               a: createRelativeLink(source, page, NoPrefetchLink),
             },
             {
-              course: page.data.course,
+              course,
             }
           )}
         />

--- a/app/docs/[year]/layout.tsx
+++ b/app/docs/[year]/layout.tsx
@@ -1,9 +1,11 @@
 import { DocsPathMemory } from '@/components/docs/docs-path-memory';
 import { SidebarBanner } from '@/components/sidebar/sidebar-banner';
 import { baseOptions } from '@/lib/layout.shared';
-import { getAvailableYears } from '@/lib/docs';
-import { source } from '@/lib/source';
-import type { Folder, Root } from 'fumadocs-core/page-tree';
+import {
+  getAvailableYears,
+  getDocsPageTree,
+  getYearPageTree,
+} from '@/lib/docs';
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import { notFound } from 'next/navigation';
 import { ReactNode } from 'react';
@@ -18,7 +20,7 @@ export default async function Layout(props: {
   if (!isYear(year)) {
     return (
       <DocsLayout
-        tree={source.getPageTree()}
+        tree={getDocsPageTree()}
         {...baseOptions()}
         sidebar={{
           tabs: false,
@@ -30,17 +32,12 @@ export default async function Layout(props: {
     );
   }
 
-  const pageTree = source.getPageTree();
-  const yearNode = pageTree.children.find(
-    (node): node is Folder => node.type === 'folder' && node.name === year
-  );
-
-  if (!yearNode) {
+  const treeAsRoot = getYearPageTree(year);
+  if (!treeAsRoot) {
     return notFound();
   }
 
   const years = getAvailableYears();
-  const treeAsRoot: Root = { ...yearNode, type: 'root' };
 
   return (
     <DocsLayout

--- a/app/docs/[year]/layout.tsx
+++ b/app/docs/[year]/layout.tsx
@@ -24,6 +24,7 @@ export default async function Layout(props: {
         {...baseOptions()}
         sidebar={{
           tabs: false,
+          prefetch: false,
         }}
       >
         <DocsPathMemory />
@@ -45,6 +46,7 @@ export default async function Layout(props: {
       {...baseOptions()}
       sidebar={{
         tabs: false,
+        prefetch: false,
         banner: (
           <SidebarBanner
             key="sidebar-banner"

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,14 +1,14 @@
-import { source } from '@/lib/source/docs';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { HOA_LAST_PATH_COOKIE } from '@/lib/constants';
+import { docsPathExists } from '@/lib/docs-paths';
 
 export default async function Page() {
   const lastPath = (await cookies()).get(HOA_LAST_PATH_COOKIE)?.value;
   const pathname = lastPath ? decodeURIComponent(lastPath) : '';
   if (pathname.startsWith('/docs/')) {
     const segments = pathname.split('/').filter(Boolean).slice(1);
-    if (segments.length >= 1 && source.getPage(segments)) {
+    if (segments.length >= 1 && docsPathExists(segments)) {
       redirect(pathname);
     }
   }

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,11 +1,27 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
+import { getAvailableYears } from '@/lib/docs';
 import { HOA_LAST_PATH_COOKIE } from '@/lib/constants';
 import { docsPathExists } from '@/lib/docs-paths';
 
+function getDocsFallbackPath() {
+  return `/docs/${getAvailableYears()[0]}`;
+}
+
+function decodeCookiePath(value: string | undefined) {
+  if (!value) return '';
+
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return '';
+  }
+}
+
 export default async function Page() {
   const lastPath = (await cookies()).get(HOA_LAST_PATH_COOKIE)?.value;
-  const pathname = lastPath ? decodeURIComponent(lastPath) : '';
+  const pathname = decodeCookiePath(lastPath);
+
   if (pathname.startsWith('/docs/')) {
     const segments = pathname.split('/').filter(Boolean).slice(1);
     if (segments.length >= 1 && docsPathExists(segments)) {
@@ -13,5 +29,5 @@ export default async function Page() {
     }
   }
 
-  redirect('/docs/2025');
+  redirect(getDocsFallbackPath());
 }

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,4 +1,4 @@
-import { source } from '@/lib/source';
+import { source } from '@/lib/source/docs';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { HOA_LAST_PATH_COOKIE } from '@/lib/constants';

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,9 @@
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import 'katex/dist/katex.css';
 import './global.css';
-import { Inter } from 'next/font/google';
 import { Toaster } from '@/components/ui/sonner';
 import Script from 'next/script';
 import type { Metadata } from 'next';
-
-const inter = Inter({
-  subsets: ['latin'],
-});
 
 export const metadata: Metadata = {
   title: 'HITSZ 课程攻略共享计划',
@@ -31,7 +26,7 @@ export const metadata: Metadata = {
 
 export default function Layout({ children }: LayoutProps<'/'>) {
   return (
-    <html lang="en" className={inter.className} suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning>
       <body className="flex min-h-screen flex-col">
         <RootProvider>
           {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import './global.css';
 import { Toaster } from '@/components/ui/sonner';
 import Script from 'next/script';
 import type { Metadata } from 'next';
+import { SearchDialog } from '@/components/search-dialog';
 
 export const metadata: Metadata = {
   title: 'HITSZ 课程攻略共享计划',
@@ -28,7 +29,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="flex min-h-screen flex-col">
-        <RootProvider>
+        <RootProvider search={{ SearchDialog }}>
           {children}
           <Toaster />
         </RootProvider>

--- a/components/hero-buttons.tsx
+++ b/components/hero-buttons.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Sidebar } from 'lucide-react';
@@ -19,14 +19,11 @@ interface HeroButtonsProps {
   yearMajorMap: Record<string, { id: string; name: string }[]>;
 }
 
-function getCookie(name: string): string | undefined {
-  if (typeof document === 'undefined') return undefined;
-  const value = `; ${document.cookie}`;
-  const parts = value.split(`; ${name}=`);
-  if (parts.length !== 2) return undefined;
-
-  const cookieValue = parts.pop()?.split(';').shift();
-  return cookieValue ? decodeURIComponent(cookieValue) : undefined;
+function hasCookie(name: string): boolean {
+  if (typeof document === 'undefined') return false;
+  return document.cookie
+    .split(';')
+    .some((cookie) => cookie.trim().startsWith(`${name}=`));
 }
 
 export function HeroButtons({ yearMajorMap }: HeroButtonsProps) {
@@ -44,21 +41,11 @@ export function HeroButtons({ yearMajorMap }: HeroButtonsProps) {
     [yearMajorMap, year]
   );
 
-  useEffect(() => {
-    const lastPath = getCookie(HOA_LAST_PATH_COOKIE);
-    if (lastPath?.startsWith('/docs')) {
-      router.prefetch(lastPath);
-    }
-  }, [router]);
-
   const handleDocsClick = useCallback(() => {
-    const lastPath = getCookie(HOA_LAST_PATH_COOKIE);
-    if (lastPath?.startsWith('/docs')) {
-      router.push(lastPath);
-    } else if (lastPath === undefined) {
-      setSelecting(true);
-    } else {
+    if (hasCookie(HOA_LAST_PATH_COOKIE)) {
       router.push('/docs');
+    } else {
+      setSelecting(true);
     }
   }, [router]);
 

--- a/components/latest-posts.tsx
+++ b/components/latest-posts.tsx
@@ -1,54 +1,30 @@
-import { blog } from '@/lib/source/posts';
 import { Cards, Card } from 'fumadocs-ui/components/card';
 import { ScrollReveal } from '@/components/scroll-reveal';
 import { formatDate } from '@/lib/utils';
-import type { InferPageType } from 'fumadocs-core/source';
 import Link from 'next/link';
 import { ArrowRight } from 'lucide-react';
+import {
+  getLatestStandaloneBlogPosts,
+  type PostSummary,
+} from '@/lib/posts-summary';
 
-type Post = InferPageType<typeof blog>;
-
-function PostCard({ post, index }: { post: Post; index: number }) {
+function PostCard({ post, index }: { post: PostSummary; index: number }) {
   return (
     <ScrollReveal delay={index * 120} className="h-full">
       <Card
-        title={post.data.title}
-        description={
-          <span className="line-clamp-1">{post.data.description}</span>
-        }
+        title={post.title}
+        description={<span className="line-clamp-1">{post.description}</span>}
         href={post.url}
         className="home-card-hover bg-fd-card [&>div:last-child]:text-brand flex h-full flex-col rounded-2xl border p-4 text-left shadow-sm transition-colors [&>div:last-child]:mt-auto [&>div:last-child]:pt-4 [&>div:last-child]:text-xs"
       >
-        {formatDate(post.data.date)}
+        {formatDate(post.date)}
       </Card>
     </ScrollReveal>
   );
 }
 
 export function LatestPosts() {
-  const pages = blog.getPages();
-  if (pages.length === 0) return null;
-
-  const seriesSlugs = new Set<string>();
-  for (const page of pages) {
-    if (page.slugs.length > 1 && page.slugs[0]) {
-      seriesSlugs.add(page.slugs[0]);
-    }
-  }
-
-  const latestPosts = pages
-    .filter((page) => {
-      return (
-        page.slugs.length === 1 &&
-        page.data?.date &&
-        !seriesSlugs.has(page.slugs[0])
-      );
-    })
-    .sort(
-      (a, b) =>
-        new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
-    )
-    .slice(0, 3);
+  const latestPosts = getLatestStandaloneBlogPosts(3);
 
   if (latestPosts.length === 0) return null;
 

--- a/components/latest-posts.tsx
+++ b/components/latest-posts.tsx
@@ -1,4 +1,4 @@
-import { blog } from '@/lib/source';
+import { blog } from '@/lib/source/posts';
 import { Cards, Card } from 'fumadocs-ui/components/card';
 import { ScrollReveal } from '@/components/scroll-reveal';
 import { formatDate } from '@/lib/utils';

--- a/components/mdx.tsx
+++ b/components/mdx.tsx
@@ -1,4 +1,6 @@
-import type { ComponentProps } from 'react';
+import type { ComponentProps, JSX } from 'react';
+import Link, { type LinkProps } from 'fumadocs-core/link';
+import { Card as FumadocsCard } from 'fumadocs-ui/components/card';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import type { MDXComponents } from 'mdx/types';
 import { CourseInfo } from '@/components/course-info';
@@ -19,6 +21,19 @@ type MdxContext = {
   course?: CourseInfoData;
 };
 
+type CardProps = ComponentProps<typeof FumadocsCard> & {
+  prefetch?: boolean;
+};
+const Card = FumadocsCard as (props: CardProps) => JSX.Element;
+
+export function NoPrefetchLink(props: LinkProps) {
+  return <Link {...props} prefetch={false} />;
+}
+
+function NoPrefetchCard(props: CardProps) {
+  return <Card {...props} prefetch={false} />;
+}
+
 export function getMDXComponents(
   components?: MDXComponents,
   context?: MdxContext
@@ -32,6 +47,7 @@ export function getMDXComponents(
     Accordions,
     Step,
     Steps,
+    Card: NoPrefetchCard,
     CourseInfo: (props: ComponentProps<typeof CourseInfo>) => (
       <CourseInfo {...props} data={props.data ?? context?.course} />
     ),

--- a/components/recent-repos.tsx
+++ b/components/recent-repos.tsx
@@ -21,6 +21,8 @@ export function RecentRepos({
   title = '最近更新的仓库',
   repos,
 }: RecentReposProps) {
+  if (repos.length === 0) return null;
+
   return (
     <section className="mx-auto w-full max-w-5xl pb-6 text-left">
       <Link

--- a/components/search-dialog.tsx
+++ b/components/search-dialog.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import {
+  SearchDialog as FumadocsSearchDialog,
+  SearchDialogClose,
+  SearchDialogContent,
+  SearchDialogFooter,
+  SearchDialogHeader,
+  SearchDialogIcon,
+  SearchDialogInput,
+  SearchDialogList,
+  SearchDialogOverlay,
+  TagsList,
+  TagsListItem,
+} from 'fumadocs-ui/components/dialog/search';
+import type { DefaultSearchDialogProps } from 'fumadocs-ui/components/dialog/search-default';
+import { useI18n } from 'fumadocs-ui/contexts/i18n';
+import { useDocsSearch } from 'fumadocs-core/search/client';
+import { useOnChange } from 'fumadocs-core/utils/use-on-change';
+import { useMemo, useState } from 'react';
+
+function EmptySearchResults() {
+  return (
+    <div className="text-fd-muted-foreground py-12 text-center text-sm">
+      No results found
+    </div>
+  );
+}
+
+export function SearchDialog({
+  defaultTag,
+  tags = [],
+  api,
+  delayMs,
+  type = 'fetch',
+  allowClear = false,
+  links = [],
+  footer,
+  ...props
+}: DefaultSearchDialogProps) {
+  const { locale } = useI18n();
+  const [tag, setTag] = useState(defaultTag);
+  const { search, setSearch, query } = useDocsSearch(
+    type === 'fetch'
+      ? {
+          type: 'fetch',
+          api,
+          locale,
+          tag,
+          delayMs,
+        }
+      : {
+          type: 'static',
+          from: api,
+          locale,
+          tag,
+          delayMs,
+        }
+  );
+  const defaultItems = useMemo(() => {
+    if (links.length === 0) return null;
+    return links.map(([name, link]) => ({
+      type: 'page' as const,
+      id: name,
+      content: name,
+      url: link,
+    }));
+  }, [links]);
+
+  useOnChange(defaultTag, (value) => {
+    setTag(value);
+  });
+
+  return (
+    <FumadocsSearchDialog
+      search={search}
+      onSearchChange={setSearch}
+      isLoading={query.isLoading}
+      {...props}
+    >
+      <SearchDialogOverlay />
+      <SearchDialogContent>
+        <SearchDialogHeader>
+          <SearchDialogIcon />
+          <SearchDialogInput />
+          <SearchDialogClose />
+        </SearchDialogHeader>
+        <SearchDialogList
+          items={query.data !== 'empty' ? query.data : defaultItems}
+          Empty={EmptySearchResults}
+        />
+      </SearchDialogContent>
+      <SearchDialogFooter>
+        {tags.length > 0 && (
+          <TagsList tag={tag} onTagChange={setTag} allowClear={allowClear}>
+            {tags.map((tag) => (
+              <TagsListItem key={tag.value} value={tag.value}>
+                {tag.name}
+              </TagsListItem>
+            ))}
+          </TagsList>
+        )}
+        {footer}
+      </SearchDialogFooter>
+    </FumadocsSearchDialog>
+  );
+}

--- a/components/search-dialog.tsx
+++ b/components/search-dialog.tsx
@@ -42,10 +42,13 @@ export function SearchDialog({
 }: DefaultSearchDialogProps) {
   const { locale } = useI18n();
   const [tag, setTag] = useState(defaultTag);
-  const client =
-    type === 'static'
-      ? oramaStaticClient({ from: api, locale, tag })
-      : fetchClient({ api, locale, tag });
+  const client = useMemo(
+    () =>
+      type === 'static'
+        ? oramaStaticClient({ from: api, locale, tag })
+        : fetchClient({ api, locale, tag }),
+    [type, api, locale, tag]
+  );
   const { search, setSearch, query } = useDocsSearch({ client, delayMs });
   const defaultItems = useMemo(() => {
     if (links.length === 0) return null;

--- a/lib/course-frontmatter.ts
+++ b/lib/course-frontmatter.ts
@@ -1,0 +1,62 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { frontmatter } from 'fumadocs-core/content/md/frontmatter';
+import z from 'zod';
+import type { CourseInfoData } from '@/lib/types';
+import { getDocsYearDir, isSafePathSegment } from '@/lib/docs-content';
+
+const courseInfoSchema = z.object({
+  credit: z.number(),
+  assessmentMethod: z.string(),
+  courseNature: z.string(),
+  hourDistribution: z.object({
+    theory: z.number(),
+    lab: z.number(),
+    practice: z.number(),
+    exercise: z.number(),
+    computer: z.number(),
+    tutoring: z.number(),
+  }),
+  gradingScheme: z.array(
+    z.object({
+      name: z.string(),
+      percent: z.number(),
+    })
+  ),
+});
+
+const cache = new Map<string, CourseInfoData | undefined>();
+
+function getDocsFile(segments: string[]): string | undefined {
+  const [year, ...rest] = segments;
+  if (!year) return undefined;
+  if (rest.some((segment) => !isSafePathSegment(segment))) return undefined;
+
+  const base = getDocsYearDir(year);
+  if (!base) return undefined;
+  const pathSegments = rest.length > 0 ? rest : ['index'];
+  const basePath = join(base, ...pathSegments);
+  const mdx = `${basePath}.mdx`;
+  if (existsSync(mdx)) return mdx;
+
+  const md = `${basePath}.md`;
+  if (existsSync(md)) return md;
+}
+
+export function getDocsCourse(segments: string[]): CourseInfoData | undefined {
+  const cacheKey = segments.join('/');
+  if (cache.has(cacheKey)) return cache.get(cacheKey);
+
+  const file = getDocsFile(segments);
+  if (!file) {
+    cache.set(cacheKey, undefined);
+    return undefined;
+  }
+
+  const data = frontmatter(readFileSync(file, 'utf8')).data as {
+    course?: unknown;
+  };
+  const course = courseInfoSchema.optional().parse(data.course);
+  cache.set(cacheKey, course);
+  return course;
+}

--- a/lib/course-frontmatter.ts
+++ b/lib/course-frontmatter.ts
@@ -56,7 +56,8 @@ export function getDocsCourse(segments: string[]): CourseInfoData | undefined {
   const data = frontmatter(readFileSync(file, 'utf8')).data as {
     course?: unknown;
   };
-  const course = courseInfoSchema.optional().parse(data.course);
+  const result = courseInfoSchema.optional().safeParse(data.course);
+  const course = result.success ? result.data : undefined;
   cache.set(cacheKey, course);
   return course;
 }

--- a/lib/docs-content.ts
+++ b/lib/docs-content.ts
@@ -2,21 +2,20 @@ import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { isYear } from '@/lib/utils';
 
-export const docsDirs = {
-  '2019': join(process.cwd(), 'content/docs/2019'),
-  '2020': join(process.cwd(), 'content/docs/2020'),
-  '2021': join(process.cwd(), 'content/docs/2021'),
-  '2022': join(process.cwd(), 'content/docs/2022'),
-  '2023': join(process.cwd(), 'content/docs/2023'),
-  '2024': join(process.cwd(), 'content/docs/2024'),
-  '2025': join(process.cwd(), 'content/docs/2025'),
-} as const;
+const docsRoot = join(process.cwd(), 'content/docs');
 
-export type DocsYear = keyof typeof docsDirs;
+export const docsDirs: Record<string, string> = Object.fromEntries(
+  readdirSync(docsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && isYear(entry.name))
+    .map((entry) => [entry.name, join(docsRoot, entry.name)])
+    .sort(([a], [b]) => a.localeCompare(b))
+);
+
+export type DocsYear = string;
 
 export function getDocsYearDir(year: string): string | undefined {
   if (!isYear(year)) return undefined;
-  return docsDirs[year as DocsYear];
+  return docsDirs[year];
 }
 
 export function isSafePathSegment(segment: string): boolean {

--- a/lib/docs-content.ts
+++ b/lib/docs-content.ts
@@ -1,0 +1,43 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { isYear } from '@/lib/utils';
+
+export const docsDirs = {
+  '2019': join(process.cwd(), 'content/docs/2019'),
+  '2020': join(process.cwd(), 'content/docs/2020'),
+  '2021': join(process.cwd(), 'content/docs/2021'),
+  '2022': join(process.cwd(), 'content/docs/2022'),
+  '2023': join(process.cwd(), 'content/docs/2023'),
+  '2024': join(process.cwd(), 'content/docs/2024'),
+  '2025': join(process.cwd(), 'content/docs/2025'),
+} as const;
+
+export type DocsYear = keyof typeof docsDirs;
+
+export function getDocsYearDir(year: string): string | undefined {
+  if (!isYear(year)) return undefined;
+  return docsDirs[year as DocsYear];
+}
+
+export function isSafePathSegment(segment: string): boolean {
+  return segment.length > 0 && segment !== '.' && segment !== '..';
+}
+
+export function getMarkdownFiles(dir: string): string[] {
+  const files: string[] = [];
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...getMarkdownFiles(fullPath));
+      continue;
+    }
+
+    if (/\.mdx?$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}

--- a/lib/docs-content.ts
+++ b/lib/docs-content.ts
@@ -1,5 +1,5 @@
 import { readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative, sep } from 'node:path';
 import { isYear } from '@/lib/utils';
 
 const docsRoot = join(process.cwd(), 'content/docs');
@@ -16,6 +16,17 @@ export type DocsYear = string;
 export function getDocsYearDir(year: string): string | undefined {
   if (!isYear(year)) return undefined;
   return docsDirs[year];
+}
+
+export function fileToSlugs(year: DocsYear, file: string): string[] {
+  const withoutExt = relative(docsDirs[year], file).replace(/\.mdx?$/, '');
+  const slugs = [year, ...withoutExt.split(sep)];
+
+  if (slugs.at(-1) === 'index') {
+    slugs.pop();
+  }
+
+  return slugs;
 }
 
 export function isSafePathSegment(segment: string): boolean {

--- a/lib/docs-content.ts
+++ b/lib/docs-content.ts
@@ -7,7 +7,7 @@ const docsRoot = join(process.cwd(), 'content/docs');
 export const docsDirs: Record<string, string> = Object.fromEntries(
   readdirSync(docsRoot, { withFileTypes: true })
     .filter((entry) => entry.isDirectory() && isYear(entry.name))
-    .map((entry) => [entry.name, join(docsRoot, entry.name)])
+    .map((entry) => [entry.name, `${docsRoot}/${entry.name}`])
     .sort(([a], [b]) => a.localeCompare(b))
 );
 

--- a/lib/docs-home.ts
+++ b/lib/docs-home.ts
@@ -1,17 +1,7 @@
 import { readdirSync } from 'node:fs';
-import { join } from 'node:path';
 import majorMapping from '@/lib/data/major_mapping.json';
 import { computeYearMajorMap, type MajorEntry } from '@/lib/docs-utils';
-
-const docsDirs = {
-  '2019': join(process.cwd(), 'content/docs/2019'),
-  '2020': join(process.cwd(), 'content/docs/2020'),
-  '2021': join(process.cwd(), 'content/docs/2021'),
-  '2022': join(process.cwd(), 'content/docs/2022'),
-  '2023': join(process.cwd(), 'content/docs/2023'),
-  '2024': join(process.cwd(), 'content/docs/2024'),
-  '2025': join(process.cwd(), 'content/docs/2025'),
-} as const;
+import { docsDirs } from '@/lib/docs-content';
 
 let yearMajorMap: Record<string, { id: string; name: string }[]> | undefined;
 

--- a/lib/docs-home.ts
+++ b/lib/docs-home.ts
@@ -1,0 +1,37 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import majorMapping from '@/lib/data/major_mapping.json';
+import { computeYearMajorMap, type MajorEntry } from '@/lib/docs-utils';
+
+const docsDirs = {
+  '2019': join(process.cwd(), 'content/docs/2019'),
+  '2020': join(process.cwd(), 'content/docs/2020'),
+  '2021': join(process.cwd(), 'content/docs/2021'),
+  '2022': join(process.cwd(), 'content/docs/2022'),
+  '2023': join(process.cwd(), 'content/docs/2023'),
+  '2024': join(process.cwd(), 'content/docs/2024'),
+  '2025': join(process.cwd(), 'content/docs/2025'),
+} as const;
+
+let yearMajorMap: Record<string, { id: string; name: string }[]> | undefined;
+
+export function getYearMajorMap() {
+  if (yearMajorMap) return yearMajorMap;
+
+  const pages: { slugs: string[] }[] = [];
+
+  for (const [year, yearDir] of Object.entries(docsDirs)) {
+    for (const majorEntry of readdirSync(yearDir, { withFileTypes: true })) {
+      if (!majorEntry.isDirectory()) continue;
+      pages.push({ slugs: [year, majorEntry.name] });
+    }
+  }
+
+  const mapping = majorMapping as unknown as Record<
+    string,
+    Record<string, MajorEntry>
+  >;
+
+  yearMajorMap = computeYearMajorMap(pages, mapping);
+  return yearMajorMap;
+}

--- a/lib/docs-paths.ts
+++ b/lib/docs-paths.ts
@@ -1,18 +1,11 @@
-import { readdirSync } from 'node:fs';
-import { join, relative, sep } from 'node:path';
-import { isYear } from '@/lib/utils';
-
-const docsDirs = {
-  '2019': join(process.cwd(), 'content/docs/2019'),
-  '2020': join(process.cwd(), 'content/docs/2020'),
-  '2021': join(process.cwd(), 'content/docs/2021'),
-  '2022': join(process.cwd(), 'content/docs/2022'),
-  '2023': join(process.cwd(), 'content/docs/2023'),
-  '2024': join(process.cwd(), 'content/docs/2024'),
-  '2025': join(process.cwd(), 'content/docs/2025'),
-} as const;
-
-type Year = keyof typeof docsDirs;
+import { relative, sep } from 'node:path';
+import {
+  docsDirs,
+  getDocsYearDir,
+  getMarkdownFiles,
+  isSafePathSegment,
+  type DocsYear,
+} from '@/lib/docs-content';
 
 export type DocsPathEntry = {
   slugs: string[];
@@ -21,35 +14,7 @@ export type DocsPathEntry = {
 let docsPathEntries: DocsPathEntry[] | undefined;
 let docsPathSet: Set<string> | undefined;
 
-function getYearDir(year: string): string | undefined {
-  if (!isYear(year)) return undefined;
-  return docsDirs[year as Year];
-}
-
-function isSafeSegment(segment: string): boolean {
-  return segment.length > 0 && segment !== '.' && segment !== '..';
-}
-
-function getMarkdownFiles(dir: string): string[] {
-  const files: string[] = [];
-
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const fullPath = join(dir, entry.name);
-
-    if (entry.isDirectory()) {
-      files.push(...getMarkdownFiles(fullPath));
-      continue;
-    }
-
-    if (/\.mdx?$/.test(entry.name)) {
-      files.push(fullPath);
-    }
-  }
-
-  return files;
-}
-
-function fileToSlugs(year: Year, file: string): string[] {
+function fileToSlugs(year: DocsYear, file: string): string[] {
   const withoutExt = relative(docsDirs[year], file).replace(/\.mdx?$/, '');
   const slugs = [year, ...withoutExt.split(sep)];
 
@@ -67,7 +32,7 @@ export function getDocsPathEntries(): DocsPathEntry[] {
 
   for (const [year, yearDir] of Object.entries(docsDirs)) {
     for (const file of getMarkdownFiles(yearDir)) {
-      entries.push({ slugs: fileToSlugs(year as Year, file) });
+      entries.push({ slugs: fileToSlugs(year as DocsYear, file) });
     }
   }
 
@@ -89,8 +54,8 @@ export function docsPathExists(segments: string[]): boolean {
   const [year, ...rest] = segments;
   if (!year) return false;
 
-  const yearDir = getYearDir(year);
-  if (!yearDir || rest.some((segment) => !isSafeSegment(segment))) {
+  const yearDir = getDocsYearDir(year);
+  if (!yearDir || rest.some((segment) => !isSafePathSegment(segment))) {
     return false;
   }
 

--- a/lib/docs-paths.ts
+++ b/lib/docs-paths.ts
@@ -1,6 +1,6 @@
-import { relative, sep } from 'node:path';
 import {
   docsDirs,
+  fileToSlugs,
   getDocsYearDir,
   getMarkdownFiles,
   isSafePathSegment,
@@ -13,17 +13,6 @@ export type DocsPathEntry = {
 
 let docsPathEntries: DocsPathEntry[] | undefined;
 let docsPathSet: Set<string> | undefined;
-
-function fileToSlugs(year: DocsYear, file: string): string[] {
-  const withoutExt = relative(docsDirs[year], file).replace(/\.mdx?$/, '');
-  const slugs = [year, ...withoutExt.split(sep)];
-
-  if (slugs.at(-1) === 'index') {
-    slugs.pop();
-  }
-
-  return slugs;
-}
 
 export function getDocsPathEntries(): DocsPathEntry[] {
   if (docsPathEntries) return docsPathEntries;

--- a/lib/docs-paths.ts
+++ b/lib/docs-paths.ts
@@ -1,0 +1,98 @@
+import { readdirSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { isYear } from '@/lib/utils';
+
+const docsDirs = {
+  '2019': join(process.cwd(), 'content/docs/2019'),
+  '2020': join(process.cwd(), 'content/docs/2020'),
+  '2021': join(process.cwd(), 'content/docs/2021'),
+  '2022': join(process.cwd(), 'content/docs/2022'),
+  '2023': join(process.cwd(), 'content/docs/2023'),
+  '2024': join(process.cwd(), 'content/docs/2024'),
+  '2025': join(process.cwd(), 'content/docs/2025'),
+} as const;
+
+type Year = keyof typeof docsDirs;
+
+export type DocsPathEntry = {
+  slugs: string[];
+};
+
+let docsPathEntries: DocsPathEntry[] | undefined;
+let docsPathSet: Set<string> | undefined;
+
+function getYearDir(year: string): string | undefined {
+  if (!isYear(year)) return undefined;
+  return docsDirs[year as Year];
+}
+
+function isSafeSegment(segment: string): boolean {
+  return segment.length > 0 && segment !== '.' && segment !== '..';
+}
+
+function getMarkdownFiles(dir: string): string[] {
+  const files: string[] = [];
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...getMarkdownFiles(fullPath));
+      continue;
+    }
+
+    if (/\.mdx?$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function fileToSlugs(year: Year, file: string): string[] {
+  const withoutExt = relative(docsDirs[year], file).replace(/\.mdx?$/, '');
+  const slugs = [year, ...withoutExt.split(sep)];
+
+  if (slugs.at(-1) === 'index') {
+    slugs.pop();
+  }
+
+  return slugs;
+}
+
+export function getDocsPathEntries(): DocsPathEntry[] {
+  if (docsPathEntries) return docsPathEntries;
+
+  const entries: DocsPathEntry[] = [];
+
+  for (const [year, yearDir] of Object.entries(docsDirs)) {
+    for (const file of getMarkdownFiles(yearDir)) {
+      entries.push({ slugs: fileToSlugs(year as Year, file) });
+    }
+  }
+
+  docsPathEntries = entries;
+  return entries;
+}
+
+function getDocsPathSet() {
+  if (!docsPathSet) {
+    docsPathSet = new Set(
+      getDocsPathEntries().map((entry) => entry.slugs.join('/'))
+    );
+  }
+
+  return docsPathSet;
+}
+
+export function docsPathExists(segments: string[]): boolean {
+  const [year, ...rest] = segments;
+  if (!year) return false;
+
+  const yearDir = getYearDir(year);
+  if (!yearDir || rest.some((segment) => !isSafeSegment(segment))) {
+    return false;
+  }
+
+  return getDocsPathSet().has(segments.join('/'));
+}

--- a/lib/docs-tree.ts
+++ b/lib/docs-tree.ts
@@ -2,18 +2,7 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { basename, extname, join } from 'node:path';
 import type { Folder, Item, Node, Root } from 'fumadocs-core/page-tree';
 import { frontmatter } from 'fumadocs-core/content/md/frontmatter';
-
-const docsDirs = {
-  '2019': join(process.cwd(), 'content/docs/2019'),
-  '2020': join(process.cwd(), 'content/docs/2020'),
-  '2021': join(process.cwd(), 'content/docs/2021'),
-  '2022': join(process.cwd(), 'content/docs/2022'),
-  '2023': join(process.cwd(), 'content/docs/2023'),
-  '2024': join(process.cwd(), 'content/docs/2024'),
-  '2025': join(process.cwd(), 'content/docs/2025'),
-} as const;
-
-type Year = keyof typeof docsDirs;
+import { docsDirs, type DocsYear } from '@/lib/docs-content';
 
 type Meta = {
   title?: string;
@@ -259,7 +248,7 @@ export function getYearPageTree(year: string): Root | undefined {
   const cached = yearPageTrees.get(year);
   if (cached) return cached;
 
-  const folder = buildFolder(docsDirs[year as Year], [year]);
+  const folder = buildFolder(docsDirs[year as DocsYear], [year]);
   const tree: Root = {
     type: 'root',
     name: folder.name,

--- a/lib/docs-tree.ts
+++ b/lib/docs-tree.ts
@@ -50,10 +50,21 @@ function readIndexInfo(dir: string): {
 
   const content = readFileSync(file, 'utf8');
   const cardTitles = new Map<string, string>();
-  const cardRe = /<Card\s+title="([^"]+)"\s+href="([^"]+)"/g;
+  const cardRe = /<Card\b([^>]*)>/g;
+  const attrRe = /\b(title|href)="([^"]*)"/g;
 
   for (const match of content.matchAll(cardRe)) {
-    cardTitles.set(match[2], match[1]);
+    let title: string | undefined;
+    let href: string | undefined;
+
+    for (const attr of match[1].matchAll(attrRe)) {
+      if (attr[1] === 'title') title = attr[2];
+      if (attr[1] === 'href') href = attr[2];
+    }
+
+    if (title && href) {
+      cardTitles.set(href, title);
+    }
   }
 
   return {

--- a/lib/docs-tree.ts
+++ b/lib/docs-tree.ts
@@ -1,0 +1,274 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { basename, extname, join } from 'node:path';
+import type { Folder, Item, Node, Root } from 'fumadocs-core/page-tree';
+import { frontmatter } from 'fumadocs-core/content/md/frontmatter';
+
+const docsDirs = {
+  '2019': join(process.cwd(), 'content/docs/2019'),
+  '2020': join(process.cwd(), 'content/docs/2020'),
+  '2021': join(process.cwd(), 'content/docs/2021'),
+  '2022': join(process.cwd(), 'content/docs/2022'),
+  '2023': join(process.cwd(), 'content/docs/2023'),
+  '2024': join(process.cwd(), 'content/docs/2024'),
+  '2025': join(process.cwd(), 'content/docs/2025'),
+} as const;
+
+type Year = keyof typeof docsDirs;
+
+type Meta = {
+  title?: string;
+  description?: string;
+  pages?: string[];
+  root?: boolean;
+  defaultOpen?: boolean;
+  collapsible?: boolean;
+};
+
+let docsPageTree: Root | undefined;
+const yearPageTrees = new Map<string, Root>();
+
+function pathToName(name: string): string {
+  return name
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function readMeta(dir: string): Meta {
+  const file = join(dir, 'meta.json');
+  if (!existsSync(file)) return {};
+  return JSON.parse(readFileSync(file, 'utf8')) as Meta;
+}
+
+function getPageFile(dir: string, name: string): string | undefined {
+  const mdx = join(dir, `${name}.mdx`);
+  if (existsSync(mdx)) return mdx;
+
+  const md = join(dir, `${name}.md`);
+  if (existsSync(md)) return md;
+}
+
+function getIndexFile(dir: string): string | undefined {
+  return getPageFile(dir, 'index');
+}
+
+function readIndexInfo(dir: string): {
+  title?: string;
+  cardTitles: Map<string, string>;
+} {
+  const file = getIndexFile(dir);
+  if (!file) return { cardTitles: new Map() };
+
+  const content = readFileSync(file, 'utf8');
+  const cardTitles = new Map<string, string>();
+  const cardRe = /<Card\s+title="([^"]+)"\s+href="([^"]+)"/g;
+
+  for (const match of content.matchAll(cardRe)) {
+    cardTitles.set(match[2], match[1]);
+  }
+
+  return {
+    title: (frontmatter(content).data as { title?: string }).title,
+    cardTitles,
+  };
+}
+
+function createPage(slugs: string[], name: string): Item {
+  const url = `/docs/${slugs.join('/')}`;
+  return {
+    type: 'page',
+    name,
+    url,
+    $id: slugs.join('/'),
+    $ref: slugs.join('/'),
+  };
+}
+
+function sortEntries(entries: string[]): string[] {
+  return entries.sort((a, b) => {
+    if (a === 'index') return -1;
+    if (b === 'index') return 1;
+    return a.localeCompare(b);
+  });
+}
+
+function buildPageFromFile(
+  file: string,
+  slugs: string[],
+  titleHint?: string
+): Item {
+  const name = titleHint ?? pathToName(basename(file, extname(file)));
+  return createPage(slugs, name);
+}
+
+function listChildNames(dir: string): string[] {
+  const names = new Set<string>();
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'meta.json') continue;
+
+    if (entry.isDirectory()) {
+      names.add(entry.name);
+      continue;
+    }
+
+    if (/\.mdx?$/.test(entry.name)) {
+      names.add(basename(entry.name, extname(entry.name)));
+    }
+  }
+
+  return sortEntries(Array.from(names));
+}
+
+function buildChild(
+  dir: string,
+  slugs: string[],
+  name: string,
+  cardTitles: Map<string, string>,
+  indexTitle?: string
+): Node | undefined {
+  const childDir = join(dir, name);
+  if (existsSync(childDir)) {
+    return buildFolder(childDir, [...slugs, name]);
+  }
+
+  const file = getPageFile(dir, name);
+  if (!file) return undefined;
+
+  const pageSlugs = name === 'index' ? slugs : [...slugs, name];
+  return buildPageFromFile(
+    file,
+    pageSlugs,
+    name === 'index'
+      ? indexTitle
+      : cardTitles.get(`/docs/${pageSlugs.join('/')}`)
+  );
+}
+
+function buildChildren(
+  dir: string,
+  slugs: string[],
+  meta: Meta,
+  cardTitles: Map<string, string>,
+  indexTitle: string | undefined,
+  excludeIndex: boolean
+): Node[] {
+  const children: Node[] = [];
+  const added = new Set<string>();
+
+  function addChild(name: string) {
+    if (excludeIndex && name === 'index') return;
+    if (added.has(name)) return;
+
+    const child = buildChild(dir, slugs, name, cardTitles, indexTitle);
+    if (!child) return;
+
+    added.add(name);
+    children.push(child);
+  }
+
+  function addRest() {
+    for (const name of listChildNames(dir)) {
+      addChild(name);
+    }
+  }
+
+  if (meta.pages) {
+    for (const item of meta.pages) {
+      if (item === '...') {
+        addRest();
+        continue;
+      }
+
+      if (item === 'z...a') {
+        for (const name of listChildNames(dir).reverse()) {
+          addChild(name);
+        }
+        continue;
+      }
+
+      if (!item.startsWith('!')) {
+        addChild(item);
+      }
+    }
+  } else {
+    addRest();
+  }
+
+  return children;
+}
+
+function buildFolder(dir: string, slugs: string[]): Folder {
+  const meta = readMeta(dir);
+  const indexFile = getIndexFile(dir);
+  const indexInfo = readIndexInfo(dir);
+  const isRoot = Boolean(meta.root);
+  const index =
+    !isRoot && indexFile
+      ? buildPageFromFile(indexFile, slugs, indexInfo.title)
+      : undefined;
+
+  return {
+    type: 'folder',
+    name: meta.title ?? indexInfo.title ?? pathToName(basename(dir)),
+    description: meta.description,
+    root: meta.root,
+    defaultOpen: meta.defaultOpen,
+    collapsible: meta.collapsible,
+    index,
+    children: buildChildren(
+      dir,
+      slugs,
+      meta,
+      indexInfo.cardTitles,
+      indexInfo.title,
+      Boolean(index)
+    ),
+    $id: slugs.join('/'),
+    $ref: {
+      folder: slugs.join('/'),
+      meta: existsSync(join(dir, 'meta.json'))
+        ? `${slugs.join('/')}/meta.json`
+        : undefined,
+    },
+  };
+}
+
+export function getDocsPageTree(): Root {
+  if (docsPageTree) return docsPageTree;
+
+  docsPageTree = {
+    type: 'root',
+    name: 'Docs',
+    children: Object.entries(docsDirs).map(([year, dir]) =>
+      buildFolder(dir, [year])
+    ),
+    $id: 'root',
+  };
+
+  return docsPageTree;
+}
+
+export function getAvailableYears(): string[] {
+  return Object.keys(docsDirs).sort((a, b) => b.localeCompare(a));
+}
+
+export function getYearPageTree(year: string): Root | undefined {
+  if (!(year in docsDirs)) return undefined;
+
+  const cached = yearPageTrees.get(year);
+  if (cached) return cached;
+
+  const folder = buildFolder(docsDirs[year as Year], [year]);
+  const tree: Root = {
+    type: 'root',
+    name: folder.name,
+    description: folder.description,
+    children: folder.children,
+    $id: year,
+    $ref: folder.$ref,
+  };
+
+  yearPageTrees.set(year, tree);
+  return tree;
+}

--- a/lib/docs.ts
+++ b/lib/docs.ts
@@ -1,11 +1,14 @@
-import { source } from '@/lib/source';
+import { source } from '@/lib/source/docs';
 import majorMapping from '@/lib/data/major_mapping.json';
 import { cache } from 'react';
+import type { Folder, Root } from 'fumadocs-core/page-tree';
 import { computeYearMajorMap, MajorEntry } from './docs-utils';
 
-export function getAvailableYears(): string[] {
+export const getDocsPageTree = cache(() => source.getPageTree());
+
+export const getAvailableYears = cache((): string[] => {
   const years: string[] = [];
-  for (const node of source.getPageTree().children) {
+  for (const node of getDocsPageTree().children) {
     if (
       node.type === 'folder' &&
       typeof node.name === 'string' &&
@@ -15,7 +18,16 @@ export function getAvailableYears(): string[] {
     }
   }
   return years.sort((a, b) => b.localeCompare(a));
-}
+});
+
+export const getYearPageTree = cache((year: string): Root | undefined => {
+  const yearNode = getDocsPageTree().children.find(
+    (node): node is Folder => node.type === 'folder' && node.name === year
+  );
+
+  if (!yearNode) return undefined;
+  return { ...yearNode, type: 'root' };
+});
 
 export const getYearMajorMap = cache(() => {
   const pages = source.getPages();

--- a/lib/docs.ts
+++ b/lib/docs.ts
@@ -1,39 +1,5 @@
-import { source } from '@/lib/source/docs';
-import majorMapping from '@/lib/data/major_mapping.json';
-import { cache } from 'react';
-import type { Folder, Root } from 'fumadocs-core/page-tree';
-import { computeYearMajorMap, MajorEntry } from './docs-utils';
-
-export const getDocsPageTree = cache(() => source.getPageTree());
-
-export const getAvailableYears = cache((): string[] => {
-  const years: string[] = [];
-  for (const node of getDocsPageTree().children) {
-    if (
-      node.type === 'folder' &&
-      typeof node.name === 'string' &&
-      /^\d{4}$/.test(node.name)
-    ) {
-      years.push(node.name);
-    }
-  }
-  return years.sort((a, b) => b.localeCompare(a));
-});
-
-export const getYearPageTree = cache((year: string): Root | undefined => {
-  const yearNode = getDocsPageTree().children.find(
-    (node): node is Folder => node.type === 'folder' && node.name === year
-  );
-
-  if (!yearNode) return undefined;
-  return { ...yearNode, type: 'root' };
-});
-
-export const getYearMajorMap = cache(() => {
-  const pages = source.getPages();
-  const mapping = majorMapping as unknown as Record<
-    string,
-    Record<string, MajorEntry>
-  >;
-  return computeYearMajorMap(pages, mapping);
-});
+export {
+  getAvailableYears,
+  getDocsPageTree,
+  getYearPageTree,
+} from '@/lib/docs-tree';

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -22,6 +22,16 @@ export type LatestCommitInfo = {
 };
 
 let allowedReposCache: Set<string> | null = null;
+const GITHUB_FETCH_TIMEOUT_MS = 800;
+const GITHUB_CACHE_TTL_MS = 5 * 60 * 1000;
+const recentReposCache = new Map<
+  number,
+  { expiresAt: number; items: RepoItem[] }
+>();
+const latestCommitCache = new Map<
+  string,
+  { expiresAt: number; item: LatestCommitInfo | null }
+>();
 
 async function getAllowedRepos(): Promise<Set<string>> {
   if (!allowedReposCache) {
@@ -42,60 +52,77 @@ async function getAllowedRepos(): Promise<Set<string>> {
  * Description is the latest commit message that does not start with "ci:".
  */
 export async function getRecentRepos(count = 3): Promise<RepoItem[]> {
+  const cached = recentReposCache.get(count);
+  if (cached && cached.expiresAt > Date.now()) return cached.items;
+
   const allowedRepos = await getAllowedRepos();
 
   const headers = githubHeaders();
 
-  // Fetch repos sorted by push date (most recent first)
-  const res = await fetch(
-    `https://api.github.com/orgs/${GITHUB_ORG}/repos?sort=pushed&direction=desc&per_page=50`,
-    { headers, next: { revalidate: 3600 } }
-  );
+  try {
+    const res = await fetch(
+      `https://api.github.com/orgs/${GITHUB_ORG}/repos?sort=pushed&direction=desc&per_page=50`,
+      githubFetchOptions(headers)
+    );
 
-  if (!res.ok) {
-    console.error('GitHub API error:', res.status, await res.text());
+    if (!res.ok) {
+      console.error('GitHub API error:', res.status, await res.text());
+      return [];
+    }
+
+    const repos: { name: string; pushed_at: string; html_url: string }[] =
+      await res.json();
+
+    const filtered = repos.filter((r) => allowedRepos.has(r.name));
+
+    const promises = filtered.slice(0, count * 2).map(async (repo) => {
+      const commitsRes = await fetch(
+        `https://api.github.com/repos/${GITHUB_ORG}/${repo.name}/commits?per_page=30`,
+        githubFetchOptions(headers)
+      );
+      if (!commitsRes.ok) return null;
+
+      const commits: {
+        commit: { message: string; author: { date: string } };
+      }[] = await commitsRes.json();
+
+      const commit = commits.find((c) => isUserCommit(c.commit.message));
+      if (!commit) return null;
+
+      return {
+        id: repo.name,
+        name: repo.name,
+        description: commit.commit.message.split('\n')[0],
+        href: repo.html_url,
+        updatedAt: commit.commit.author.date,
+      };
+    });
+
+    const results = (await Promise.all(promises)).filter(
+      (item): item is RepoItem => item !== null
+    );
+
+    const items = results
+      .sort(
+        (a, b) =>
+          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+      )
+      .slice(0, count);
+
+    recentReposCache.set(count, {
+      expiresAt: Date.now() + GITHUB_CACHE_TTL_MS,
+      items,
+    });
+
+    return items;
+  } catch {
+    recentReposCache.set(count, {
+      expiresAt: Date.now() + GITHUB_CACHE_TTL_MS,
+      items: [],
+    });
+
     return [];
   }
-
-  const repos: { name: string; pushed_at: string; html_url: string }[] =
-    await res.json();
-
-  // Filter to allowed repos and take enough candidates
-  const filtered = repos.filter((r) => allowedRepos.has(r.name));
-
-  // For each repo, fetch the latest non-ci commit message
-  const promises = filtered.slice(0, count * 2).map(async (repo) => {
-    const commitsRes = await fetch(
-      `https://api.github.com/repos/${GITHUB_ORG}/${repo.name}/commits?per_page=30`,
-      { headers, next: { revalidate: 3600 } }
-    );
-    if (!commitsRes.ok) return null;
-
-    const commits: { commit: { message: string; author: { date: string } } }[] =
-      await commitsRes.json();
-
-    const commit = commits.find((c) => isUserCommit(c.commit.message));
-    if (!commit) return null;
-
-    return {
-      id: repo.name,
-      name: repo.name,
-      description: commit.commit.message.split('\n')[0],
-      href: repo.html_url,
-      updatedAt: commit.commit.author.date,
-    };
-  });
-
-  const results = (await Promise.all(promises)).filter(
-    (item): item is RepoItem => item !== null
-  );
-
-  return results
-    .sort(
-      (a, b) =>
-        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-    )
-    .slice(0, count);
 }
 
 const IGNORED_PREFIXES = [
@@ -122,41 +149,74 @@ function githubHeaders(): HeadersInit {
   return headers;
 }
 
+function githubFetchOptions(headers: HeadersInit) {
+  return {
+    headers,
+    next: { revalidate: 3600 },
+    signal: AbortSignal.timeout(GITHUB_FETCH_TIMEOUT_MS),
+  };
+}
+
 /**
  * Fetch the latest non-ci commit for a specific repo.
  */
 export async function getLatestCommit(
   repoName: string
 ): Promise<LatestCommitInfo | null> {
+  const cached = latestCommitCache.get(repoName);
+  if (cached && cached.expiresAt > Date.now()) return cached.item;
+
   const headers = githubHeaders();
 
-  const res = await fetch(
-    `https://api.github.com/repos/${GITHUB_ORG}/${repoName}/commits?per_page=50`,
-    { headers, next: { revalidate: 3600 } }
-  );
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${GITHUB_ORG}/${repoName}/commits?per_page=50`,
+      githubFetchOptions(headers)
+    );
 
-  if (!res.ok) return null;
+    if (!res.ok) return null;
 
-  const commits: {
-    sha: string;
-    html_url: string;
-    commit: {
-      message: string;
-      author: { name: string; date: string };
+    const commits: {
+      sha: string;
+      html_url: string;
+      commit: {
+        message: string;
+        author: { name: string; date: string };
+      };
+      author: { login: string; html_url: string; avatar_url: string } | null;
+    }[] = await res.json();
+
+    const commit = commits.find((c) => isUserCommit(c.commit.message));
+    if (!commit) {
+      latestCommitCache.set(repoName, {
+        expiresAt: Date.now() + GITHUB_CACHE_TTL_MS,
+        item: null,
+      });
+      return null;
+    }
+
+    const item = {
+      authorName: commit.author?.login ?? commit.commit.author.name,
+      authorUrl:
+        commit.author?.html_url ?? `https://github.com/${commit.author?.login}`,
+      authorAvatarUrl: commit.author?.avatar_url ?? '',
+      message: commit.commit.message.split('\n')[0],
+      commitUrl: commit.html_url,
+      date: commit.commit.author.date,
     };
-    author: { login: string; html_url: string; avatar_url: string } | null;
-  }[] = await res.json();
 
-  const commit = commits.find((c) => isUserCommit(c.commit.message));
-  if (!commit) return null;
+    latestCommitCache.set(repoName, {
+      expiresAt: Date.now() + GITHUB_CACHE_TTL_MS,
+      item,
+    });
 
-  return {
-    authorName: commit.author?.login ?? commit.commit.author.name,
-    authorUrl:
-      commit.author?.html_url ?? `https://github.com/${commit.author?.login}`,
-    authorAvatarUrl: commit.author?.avatar_url ?? '',
-    message: commit.commit.message.split('\n')[0],
-    commitUrl: commit.html_url,
-    date: commit.commit.author.date,
-  };
+    return item;
+  } catch {
+    latestCommitCache.set(repoName, {
+      expiresAt: Date.now() + GITHUB_CACHE_TTL_MS,
+      item: null,
+    });
+
+    return null;
+  }
 }

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -22,7 +22,7 @@ export type LatestCommitInfo = {
 };
 
 let allowedReposCache: Set<string> | null = null;
-const GITHUB_FETCH_TIMEOUT_MS = 800;
+const GITHUB_FETCH_TIMEOUT_MS = 3000;
 const GITHUB_CACHE_TTL_MS = 5 * 60 * 1000;
 const recentReposCache = new Map<
   number,
@@ -116,11 +116,6 @@ export async function getRecentRepos(count = 3): Promise<RepoItem[]> {
 
     return items;
   } catch {
-    recentReposCache.set(count, {
-      expiresAt: Date.now() + GITHUB_CACHE_TTL_MS,
-      items: [],
-    });
-
     return [];
   }
 }

--- a/lib/posts-summary.ts
+++ b/lib/posts-summary.ts
@@ -131,10 +131,9 @@ export function getPostListItems(kind: PostKind) {
   const seriesItems = [...seriesMap.entries()]
     .filter(([, entry]) => entry.posts.length > 0)
     .map(([slug, entry]) => {
-      const dates = [
-        entry.index?.date,
-        ...entry.posts.map((post) => post.date),
-      ].map((date) => new Date(date as string | Date).getTime());
+      const dates = [entry.index?.date, ...entry.posts.map((post) => post.date)]
+        .filter((date): date is string | Date => Boolean(date))
+        .map((date) => new Date(date).getTime());
       const latestDate = dates.length > 0 ? new Date(Math.max(...dates)) : null;
       return {
         type: 'series' as const,

--- a/lib/posts-summary.ts
+++ b/lib/posts-summary.ts
@@ -1,0 +1,186 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { frontmatter } from 'fumadocs-core/content/md/frontmatter';
+
+type PostKind = 'blog' | 'news';
+
+type PostFrontmatter = {
+  title?: string;
+  description?: string;
+  date?: string | Date;
+  weight?: number;
+  authors?: { name: string; link?: string; image?: string }[];
+};
+
+export type PostSummary = {
+  title: string;
+  description?: string;
+  date: string | Date;
+  weight?: number;
+  authors?: { name: string; link?: string; image?: string }[];
+  url: string;
+  slugs: string[];
+};
+
+const roots = {
+  blog: join(process.cwd(), 'content/blog'),
+  news: join(process.cwd(), 'content/news'),
+} as const;
+
+const summaries = new Map<PostKind, PostSummary[]>();
+
+function getMarkdownFiles(dir: string): string[] {
+  const files: string[] = [];
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...getMarkdownFiles(fullPath));
+      continue;
+    }
+
+    if (/\.mdx?$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function getSlugs(root: string, file: string) {
+  const withoutExt = relative(root, file).replace(/\.mdx?$/, '');
+  const slugs = withoutExt.split(sep);
+
+  if (slugs.at(-1) === 'index') {
+    slugs.pop();
+  }
+
+  return slugs;
+}
+
+export function getPostSummaries(kind: PostKind): PostSummary[] {
+  const cached = summaries.get(kind);
+  if (cached) return cached;
+
+  const root = roots[kind];
+  const posts = getMarkdownFiles(root)
+    .map((file): PostSummary | undefined => {
+      const data = frontmatter(readFileSync(file, 'utf8'))
+        .data as PostFrontmatter;
+      const slugs = getSlugs(root, file);
+
+      if (!data.title || !data.date || slugs.length === 0) {
+        return undefined;
+      }
+
+      return {
+        title: data.title,
+        description: data.description,
+        date: data.date,
+        weight: data.weight,
+        authors: data.authors,
+        url: `/${kind}/${slugs.join('/')}`,
+        slugs,
+      };
+    })
+    .filter((post): post is PostSummary => Boolean(post));
+
+  summaries.set(kind, posts);
+  return posts;
+}
+
+export function getSeriesPosts(kind: PostKind, seriesSlug: string) {
+  return getPostSummaries(kind)
+    .filter((post) => post.slugs.length > 1 && post.slugs[0] === seriesSlug)
+    .sort((a, b) => {
+      const wa = a.weight ?? Infinity;
+      const wb = b.weight ?? Infinity;
+      if (wa !== wb) return wa - wb;
+
+      const direction = kind === 'blog' ? 1 : -1;
+      return (
+        direction * (new Date(a.date).getTime() - new Date(b.date).getTime())
+      );
+    });
+}
+
+export function getPostListItems(kind: PostKind) {
+  const pages = getPostSummaries(kind);
+  const seriesMap = new Map<
+    string,
+    {
+      index?: PostSummary;
+      posts: PostSummary[];
+    }
+  >();
+
+  for (const page of pages) {
+    const seriesSlug = page.slugs[0];
+    if (!seriesSlug) continue;
+
+    const series = seriesMap.get(seriesSlug) ?? { posts: [] };
+    if (page.slugs.length === 1) {
+      series.index = page;
+    } else {
+      series.posts.push(page);
+    }
+    seriesMap.set(seriesSlug, series);
+  }
+
+  const seriesItems = [...seriesMap.entries()]
+    .filter(([, entry]) => entry.posts.length > 0)
+    .map(([slug, entry]) => {
+      const dates = [
+        entry.index?.date,
+        ...entry.posts.map((post) => post.date),
+      ].map((date) => new Date(date as string | Date).getTime());
+      const latestDate = dates.length > 0 ? new Date(Math.max(...dates)) : null;
+      return {
+        type: 'series' as const,
+        slug,
+        title: entry.index?.title ?? slug,
+        description: entry.index?.description ?? '',
+        date: latestDate,
+      };
+    });
+
+  const seriesSlugs = new Set(seriesItems.map((item) => item.slug));
+  const postItems = pages
+    .filter(
+      (page) => page.slugs.length === 1 && !seriesSlugs.has(page.slugs[0])
+    )
+    .map((post) => ({
+      type: 'post' as const,
+      slug: post.slugs[0],
+      title: post.title,
+      description: post.description,
+      date: new Date(post.date),
+      url: post.url,
+    }));
+
+  return [...seriesItems, ...postItems].sort((a, b) => {
+    const aDate = a.date?.getTime() ?? 0;
+    const bDate = b.date?.getTime() ?? 0;
+    return bDate - aDate;
+  });
+}
+
+export function getLatestStandaloneBlogPosts(count = 3) {
+  const posts = getPostSummaries('blog');
+  const seriesSlugs = new Set(
+    posts
+      .filter((post) => post.slugs.length > 1 && post.slugs[0])
+      .map((post) => post.slugs[0])
+  );
+
+  return posts
+    .filter(
+      (post) =>
+        post.slugs.length === 1 &&
+        Boolean(post.slugs[0]) &&
+        !seriesSlugs.has(post.slugs[0])
+    )
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .slice(0, count);
+}

--- a/lib/redirect.ts
+++ b/lib/redirect.ts
@@ -1,4 +1,4 @@
-import { source } from '@/lib/source';
+import { source } from '@/lib/source/docs';
 import { SEMESTER_NAMES, COURSE_CODE_RE } from '@/lib/constants';
 import { isYear } from '@/lib/utils';
 

--- a/lib/redirect.ts
+++ b/lib/redirect.ts
@@ -1,6 +1,6 @@
-import { source } from '@/lib/source/docs';
 import { SEMESTER_NAMES, COURSE_CODE_RE } from '@/lib/constants';
 import { isYear } from '@/lib/utils';
+import { getDocsPathEntries } from '@/lib/docs-paths';
 
 function isSemester(segment: string): boolean {
   return SEMESTER_NAMES.has(segment);
@@ -47,10 +47,9 @@ export function findRedirect(
     if (!isCourseCode(courseCode)) return null;
   }
 
-  const allPages = source.getPages();
   const matches: { slugs: string[] }[] = [];
 
-  for (const page of allPages) {
+  for (const page of getDocsPathEntries()) {
     if (page.slugs.length < 4) continue;
     const pageCourseCode = page.slugs[3]?.toUpperCase();
     if (pageCourseCode !== courseCode) continue;

--- a/lib/search-index.ts
+++ b/lib/search-index.ts
@@ -1,9 +1,13 @@
 import { readFileSync } from 'node:fs';
-import { relative, sep } from 'node:path';
 import type { SortedResult } from 'fumadocs-core/search';
 import { createContentHighlighter } from 'fumadocs-core/search';
 import { frontmatter } from 'fumadocs-core/content/md/frontmatter';
-import { docsDirs, getMarkdownFiles, type DocsYear } from '@/lib/docs-content';
+import {
+  docsDirs,
+  fileToSlugs,
+  getMarkdownFiles,
+  type DocsYear,
+} from '@/lib/docs-content';
 
 type DocsFrontmatter = {
   title?: string;
@@ -25,17 +29,6 @@ function pathToName(name: string): string {
     .split('-')
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
-}
-
-function fileToSlugs(year: DocsYear, file: string): string[] {
-  const withoutExt = relative(docsDirs[year], file).replace(/\.mdx?$/, '');
-  const slugs = [year, ...withoutExt.split(sep)];
-
-  if (slugs.at(-1) === 'index') {
-    slugs.pop();
-  }
-
-  return slugs;
 }
 
 function cleanMarkdown(value: string): string {

--- a/lib/search-index.ts
+++ b/lib/search-index.ts
@@ -1,0 +1,150 @@
+import { readFileSync } from 'node:fs';
+import { relative, sep } from 'node:path';
+import type { SortedResult } from 'fumadocs-core/search';
+import { createContentHighlighter } from 'fumadocs-core/search';
+import { frontmatter } from 'fumadocs-core/content/md/frontmatter';
+import { docsDirs, getMarkdownFiles, type DocsYear } from '@/lib/docs-content';
+
+type DocsFrontmatter = {
+  title?: string;
+  description?: string;
+};
+
+type SearchEntry = {
+  title: string;
+  description: string;
+  content: string;
+  breadcrumbs: string[];
+  url: string;
+};
+
+let cachedEntries: SearchEntry[] | undefined;
+
+function pathToName(name: string): string {
+  return name
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function fileToSlugs(year: DocsYear, file: string): string[] {
+  const withoutExt = relative(docsDirs[year], file).replace(/\.mdx?$/, '');
+  const slugs = [year, ...withoutExt.split(sep)];
+
+  if (slugs.at(-1) === 'index') {
+    slugs.pop();
+  }
+
+  return slugs;
+}
+
+function cleanMarkdown(value: string): string {
+  return value
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[>*_~#`{}[\]()-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function getEntries(): SearchEntry[] {
+  if (cachedEntries) return cachedEntries;
+
+  cachedEntries = Object.entries(docsDirs).flatMap(([year, dir]) =>
+    getMarkdownFiles(dir).map((file) => {
+      const raw = readFileSync(file, 'utf8');
+      const parsed = frontmatter(raw);
+      const data = parsed.data as DocsFrontmatter;
+      const slugs = fileToSlugs(year as DocsYear, file);
+      const lastSlug = slugs.at(-1);
+
+      return {
+        title:
+          data.title ?? (lastSlug ? pathToName(lastSlug) : pathToName(year)),
+        description: data.description ?? '',
+        content: cleanMarkdown(parsed.content),
+        breadcrumbs: slugs.slice(0, -1),
+        url: `/docs/${slugs.join('/')}`,
+      };
+    })
+  );
+
+  return cachedEntries;
+}
+
+function getSnippet(content: string, terms: string[]): string {
+  const lower = content.toLowerCase();
+  const matchIndex = terms
+    .map((term) => lower.indexOf(term))
+    .filter((index) => index >= 0)
+    .sort((a, b) => a - b)[0];
+
+  if (matchIndex === undefined) return content.slice(0, 180);
+
+  const start = Math.max(0, matchIndex - 80);
+  const end = Math.min(content.length, matchIndex + 180);
+  const prefix = start > 0 ? '...' : '';
+  const suffix = end < content.length ? '...' : '';
+  return `${prefix}${content.slice(start, end)}${suffix}`;
+}
+
+function scoreEntry(entry: SearchEntry, terms: string[]): number {
+  const title = entry.title.toLowerCase();
+  const description = entry.description.toLowerCase();
+  const content = entry.content.toLowerCase();
+  let score = 0;
+
+  for (const term of terms) {
+    if (title.includes(term)) score += 100;
+    if (description.includes(term)) score += 40;
+    if (content.includes(term)) score += 10;
+    if (entry.url.toLowerCase().includes(term)) score += 20;
+  }
+
+  return score;
+}
+
+export function searchDocs(query: string, limit = 60): SortedResult[] {
+  const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+
+  if (terms.length === 0) return [];
+
+  const highlighter = createContentHighlighter(query);
+
+  const results = getEntries()
+    .map((entry) => ({ entry, score: scoreEntry(entry, terms) }))
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .flatMap(({ entry }): SortedResult[] => {
+      const titleResult: SortedResult = {
+        id: entry.url,
+        type: 'page',
+        content: highlighter.highlightMarkdown(entry.title),
+        breadcrumbs: entry.breadcrumbs,
+        url: entry.url,
+      };
+      const snippet = getSnippet(
+        `${entry.description} ${entry.content}`.trim(),
+        terms
+      );
+
+      if (!snippet) return [titleResult];
+
+      return [
+        titleResult,
+        {
+          id: `${entry.url}-content`,
+          type: 'text',
+          content: highlighter.highlightMarkdown(snippet),
+          breadcrumbs: entry.breadcrumbs,
+          url: entry.url,
+        },
+      ];
+    });
+
+  return results.slice(0, limit);
+}

--- a/lib/source/docs.ts
+++ b/lib/source/docs.ts
@@ -1,10 +1,8 @@
-import { docs, blogPosts, newsPosts } from 'fumadocs-mdx:collections/server';
+import { docs } from 'fumadocs-mdx:collections/dynamic';
 import { type InferPageType, loader } from 'fumadocs-core/source';
 import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
-import { toFumadocsSource } from 'fumadocs-mdx/runtime/server';
 import { i18n } from '@/lib/i18n';
 
-// See https://fumadocs.dev/docs/headless/source-api for more info
 export const source = loader({
   baseUrl: '/docs',
   source: docs.toFumadocsSource(),
@@ -20,13 +18,3 @@ export function getPageImage(page: InferPageType<typeof source>) {
     url: `/og/docs/${segments.join('/')}`,
   };
 }
-
-export const blog = loader({
-  baseUrl: '/blog',
-  source: toFumadocsSource(blogPosts, []),
-});
-
-export const news = loader({
-  baseUrl: '/news',
-  source: toFumadocsSource(newsPosts, []),
-});

--- a/lib/source/posts.ts
+++ b/lib/source/posts.ts
@@ -1,0 +1,13 @@
+import { blogPosts, newsPosts } from 'fumadocs-mdx:collections/server';
+import { loader } from 'fumadocs-core/source';
+import { toFumadocsSource } from 'fumadocs-mdx/runtime/server';
+
+export const blog = loader({
+  baseUrl: '/blog',
+  source: toFumadocsSource(blogPosts, []),
+});
+
+export const news = loader({
+  baseUrl: '/news',
+  source: toFumadocsSource(newsPosts, []),
+});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "knip": "knip"
   },
   "dependencies": {
-    "@orama/tokenizers": "^3.1.18",
     "@radix-ui/react-checkbox": "^1.3.4",
     "@radix-ui/react-slot": "^1.2.5",
     "@radix-ui/react-switch": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@orama/tokenizers':
-        specifier: ^3.1.18
-        version: 3.1.18
       '@radix-ui/react-checkbox':
         specifier: ^1.3.4
         version: 1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -578,10 +575,6 @@ packages:
 
   '@orama/orama@3.1.18':
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
-    engines: {node: '>= 20.0.0'}
-
-  '@orama/tokenizers@3.1.18':
-    resolution: {integrity: sha512-Ra4dFddWZ7hCGPAehnd/6QZjlzQvczYSt1y1Fq4HteJqRu2yvfR6fXvxiUnKi+HIgJYPxKhebJEjvJdF8LYQWg==}
     engines: {node: '>= 20.0.0'}
 
   '@oxc-parser/binding-android-arm-eabi@0.133.0':
@@ -3556,10 +3549,6 @@ snapshots:
     optional: true
 
   '@orama/orama@3.1.18': {}
-
-  '@orama/tokenizers@3.1.18':
-    dependencies:
-      '@orama/orama': 3.1.18
 
   '@oxc-parser/binding-android-arm-eabi@0.133.0':
     optional: true

--- a/source.config.ts
+++ b/source.config.ts
@@ -35,6 +35,7 @@ const courseInfoSchema = z.object({
 export const docs = defineDocs({
   dir: 'content/docs',
   docs: {
+    dynamic: true,
     schema: frontmatterSchema.extend({
       course: courseInfoSchema.optional(),
     }),

--- a/source.config.ts
+++ b/source.config.ts
@@ -4,6 +4,7 @@ import {
   defineDocs,
   frontmatterSchema,
   metaSchema,
+  applyMdxPreset,
 } from 'fumadocs-mdx/config';
 import z from 'zod';
 import remarkMath from 'remark-math';
@@ -39,6 +40,14 @@ export const docs = defineDocs({
     schema: frontmatterSchema.extend({
       course: courseInfoSchema.optional(),
     }),
+    mdxOptions: (environment) =>
+      applyMdxPreset({
+        remarkImageOptions: {
+          external: false,
+        },
+        remarkPlugins: [remarkMath, remarkAlert],
+        rehypePlugins: (plugins) => [rehypeKatex, ...plugins],
+      })(environment),
     postprocess: {
       includeProcessedMarkdown: false,
     },

--- a/source.config.ts
+++ b/source.config.ts
@@ -11,35 +11,10 @@ import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import remarkAlert from 'remark-github-blockquote-alert';
 
-// You can customise Zod schemas for frontmatter and `meta.json` here
-// see https://fumadocs.dev/docs/mdx/collections
-const courseInfoSchema = z.object({
-  credit: z.number(),
-  assessmentMethod: z.string(),
-  courseNature: z.string(),
-  hourDistribution: z.object({
-    theory: z.number(),
-    lab: z.number(),
-    practice: z.number(),
-    exercise: z.number(),
-    computer: z.number(),
-    tutoring: z.number(),
-  }),
-  gradingScheme: z.array(
-    z.object({
-      name: z.string(),
-      percent: z.number(),
-    })
-  ),
-});
-
 export const docs = defineDocs({
   dir: 'content/docs',
   docs: {
     dynamic: true,
-    schema: frontmatterSchema.extend({
-      course: courseInfoSchema.optional(),
-    }),
     mdxOptions: (environment) =>
       applyMdxPreset({
         remarkImageOptions: {


### PR DESCRIPTION
## Summary
- Split Fumadocs source loading so home, docs layout, docs redirects, blog/news lists, and latest posts no longer import the full generated docs/posts source.
- Added lightweight filesystem-backed helpers for docs paths, docs tree, home year/major data, post summaries, course frontmatter, and search.
- Moved course metadata out of the generated Fumadocs docs module and load it on demand for the active docs page.
- Disabled prefetch for heavy docs sidebar/MDX links to avoid background route compile cascades in dev.
- Replaced the search API path that compiled/indexed the full docs source with a cached raw-MDX search path.
- Fixed the empty-search-results React crash by using a local search dialog with a hook-safe empty state.

## Results
- Generated `.source/dynamic.ts` size: `4,673,164` bytes before -> `2,969,290` bytes after, about `36.5%` smaller.
- Search API, matching query `计算机专业导论`:
  - hosted old version first observed request: `77.386s`; this branch local production first request: `0.568s`, about `136x` faster.
  - hosted old version warm requests: `1.070-1.540s`; this branch warm requests: `0.057-0.078s`, about `14-27x` faster across samples, about `20x` by average sample time.
- Search API, no-match query `no-such-term-310-test`:
  - hosted old version observed request: `62.168s`; this branch first request: `0.310s`, about `200x` faster.
  - hosted old version warm request: `0.945s`; this branch warm requests: `0.056-0.064s`, about `15-17x` faster.
- Dev docs index smoke: opening `/docs/2025` no longer triggered the previous background fan-out of linked course page compiles; only the directly requested route was compiled.

## Verification
- `make check`
- `pnpm run build`
- `agent-browser` smoke for `/`, `/blog`, `/news`, `/docs/2025`, and a course page
- `agent-browser` search smoke for both no-result and normal-result queries

Co-authored-by: Codex <codex@openai.com>