### PR TITLE
fix(course-info): improve empty grading prompt

### DIFF
--- a/components/course-info/course-info.tsx
+++ b/components/course-info/course-info.tsx
@@ -32,6 +32,8 @@ export function CourseInfo({ data, className }: CourseInfoProps) {
     );
   }
 
+  const hasGradingScheme = data.gradingScheme.length > 0;
+
   return (
     <section
       className={cn(
@@ -81,8 +83,18 @@ export function CourseInfo({ data, className }: CourseInfoProps) {
           </dl>
         </div>
 
-        <div className="border-t pt-4">
-          <div className="mb-3 flex items-center gap-2">
+        <div
+          className={cn(
+            'border-t pt-4',
+            !hasGradingScheme && 'flex flex-wrap items-center gap-4'
+          )}
+        >
+          <div
+            className={cn(
+              'flex items-center gap-2',
+              hasGradingScheme && 'mb-3'
+            )}
+          >
             <h4 className="flex items-center gap-2 text-sm font-semibold">
               <Award className="size-4 text-yellow-500" />
               成绩构成

--- a/components/course-info/grading-bar.tsx
+++ b/components/course-info/grading-bar.tsx
@@ -14,7 +14,19 @@ const COLOR_CLASSES = [
 export function GradingBar({ scheme }: { scheme: CourseGradingScheme }) {
   if (!scheme || scheme.length === 0) {
     return (
-      <div className="text-muted-foreground text-sm">暂无成绩构成信息</div>
+      <div className="text-muted-foreground text-sm">
+        暂无成绩构成信息，请到{' '}
+        <a
+          className="text-fd-primary underline underline-offset-4"
+          href="https://wiki.hoa.moe/contribution-guide/grades"
+          target="_blank"
+          rel="noopener"
+          referrerPolicy="origin"
+        >
+          HOA Wiki
+        </a>{' '}
+        查看如何帮我们补充
+      </div>
     );
   }
 


### PR DESCRIPTION
## Summary
- keep the missing grading prompt on the same row as the section title
- link the prompt to the HOA Wiki grades contribution guide
- preserve the original missing-grading wording while spacing the HOA Wiki link cleanly

## Checks
- make check