### PR TITLE
ci: merge prepare/build/deploy into single job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,17 +111,17 @@ jobs:
           GHCR_TOKEN: ${{ github.token }}
           FUMA_GITHUB_API_TOKEN: ${{ secrets.FUMA_GITHUB_API_TOKEN }}
         with:
-          host: ${{ secrets.VPS_HOST }}
-          username: ${{ secrets.VPS_USER }}
+          host: ${{ vars.VPS_HOST }}
+          username: ${{ vars.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
-          port: ${{ secrets.VPS_PORT }}
+          port: ${{ vars.VPS_PORT }}
           envs: GHCR_TOKEN,FUMA_GITHUB_API_TOKEN
           script: |
             set -euo pipefail
             image_ref='${{ env.IMAGE_NAME }}:latest'
             container='hoa-fuma'
-            port='${{ secrets.VPS_APP_PORT }}'
+            port='${{ vars.VPS_APP_PORT }}'
 
             echo "${GHCR_TOKEN}" | docker login ghcr.io -u '${{ github.actor }}' --password-stdin
             docker pull "${image_ref}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  prepare:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    outputs:
-      trigger_deploy: ${{ steps.check_changes.outputs.trigger_deploy }}
+  ci:
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.0
@@ -32,74 +30,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: make content
 
-      - name: Check for changes
-        id: check_changes
-        run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "trigger_deploy=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          git fetch origin production --depth=1 2>/dev/null || { echo "trigger_deploy=true" >> $GITHUB_OUTPUT; exit 0; }
-          mkdir -p /tmp/prod
-          git archive origin/production content/ | tar -x -C /tmp/prod
-          changed=false
-          echo "Checking for changes in content/..."
-          while IFS= read -r -d '' file; do
-            rel_path="${file#content/}"
-            prod_file="/tmp/prod/content/$rel_path"
-            if [ ! -f "$prod_file" ]; then
-              echo "Added: content/$rel_path"
-              changed=true
-            elif ! diff -u "$prod_file" "$file" > /tmp/diff_output.txt 2>&1; then
-              echo "Modified: content/$rel_path"
-              echo "--- Diff ---"
-              cat /tmp/diff_output.txt
-              echo "------------"
-              changed=true
-            fi
-          done < <(find content/ -type f -print0 2>/dev/null)
-
-          while IFS= read -r -d '' file; do
-            rel_path="${file#/tmp/prod/content/}"
-            build_file="content/$rel_path"
-            if [ ! -f "$build_file" ]; then
-              echo "Deleted: content/$rel_path"
-              changed=true
-            fi
-          done < <(find /tmp/prod/content/ -type f -print0 2>/dev/null)
-
-          if [ "$changed" = "true" ]; then
-            echo "trigger_deploy=true" >> $GITHUB_OUTPUT
-          else
-            echo "trigger_deploy=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Upload content artifact
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: content
-          path: content/
-          retention-days: 1
-
-  build:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    needs: prepare
-    if: needs.prepare.outputs.trigger_deploy == 'true'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7.0.0
-        with:
-          repository: ${{ github.repository }}
-          ref: main
-
       - name: Remove placeholder content
         run: rm -rf content/docs content/blog content/news
-
-      - name: Download content artifact
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: content
-          path: content/
 
       - uses: pnpm/action-setup@v6.0.9
         with:
@@ -122,14 +54,17 @@ jobs:
       - name: Run knip
         run: pnpm run knip
 
+      - name: Check types
+        run: pnpm run types:check
+
       - name: Fetch external data
         run: ./scripts/fetch-data.sh
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@v4.2.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -137,7 +72,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6.1.0
+        uses: docker/metadata-action@v6.2.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -145,7 +80,7 @@ jobs:
             type=sha,format=short
 
       - name: Build and push image
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@v7.3.0
         with:
           context: .
           build-args: |
@@ -163,12 +98,8 @@ jobs:
           git commit -m "docs: update course pages" || echo "No changes to commit"
           git push origin HEAD:production --force
 
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Tailscale
-        uses: tailscale/github-action@v4.1.2
+        uses: tailscale/github-action@v4.1.3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -6,8 +6,8 @@ permissions:
   pull-requests: write
 
 env:
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
   NEXT_TELEMETRY_DISABLED: 1
 


### PR DESCRIPTION
## Description

Merge the three CI jobs (prepare/build/deploy) into a single job, and move non-sensitive configuration from secrets to variables.

Changes:
- Merge prepare, build, deploy jobs into one `ci` job
- Remove the "Check for changes" step and artifact passing
- Add `types:check` step
- Move non-sensitive config (`VPS_HOST`, `VPS_USER`, `VPS_PORT`, `VPS_APP_PORT`) from secrets to vars
- Move `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` from secrets to vars in preview workflow

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

After merging, set up the following **Variables** in GitHub Actions settings and remove the old **Secrets** with the same names:

- `VPS_HOST`, `VPS_USER`, `VPS_PORT`, `VPS_APP_PORT`
- `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`