### PR TITLE
fix: defer '...' wildcard processing to end of sidebar page tree

### DIFF
--- a/lib/docs-tree.ts
+++ b/lib/docs-tree.ts
@@ -174,22 +174,33 @@ function buildChildren(
   }
 
   if (meta.pages) {
+    let hasRest = false;
+    let hasRestReversed = false;
+
     for (const item of meta.pages) {
       if (item === '...') {
-        addRest();
+        hasRest = true;
         continue;
       }
 
       if (item === 'z...a') {
-        for (const name of listChildNames(dir).reverse()) {
-          addChild(name);
-        }
+        hasRestReversed = true;
         continue;
       }
 
       if (!item.startsWith('!')) {
         addChild(item);
       }
+    }
+
+    if (hasRestReversed) {
+      for (const name of listChildNames(dir).reverse()) {
+        addChild(name);
+      }
+    }
+
+    if (hasRest) {
+      addRest();
     }
   } else {
     addRest();


### PR DESCRIPTION
## Summary

Fixes #110 - Left sidebar menu order

### Problem

The sidebar menu order didn't match the docs page. The meta.json files generated by `hoa-backend` placed the `"..."` wildcard at the beginning of the `pages` array, causing all sidebar items to appear in alphabetical order and ignoring the intended chronological semester ordering (Freshman Fall → Senior Spring → cross-specialty → general-knowledge → innovation-and-proctice).

### Solution

Modified `lib/docs-tree.ts` to defer both `"..."` and `"z...a"` wildcard processing to the end. This ensures explicitly ordered items always appear first, regardless of where the wildcards appear in the `pages` array.

A companion fix has also been submitted to `hoa-backend` to correct the generation order at the source.